### PR TITLE
Fix: Correct PostCSS configuration for Tailwind CSS v4

### DIFF
--- a/system-design-study-app/postcss.config.js
+++ b/system-design-study-app/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
I've reverted the change to `system-design-study-app/postcss.config.js` that incorrectly tried to use `tailwindcss` directly as a PostCSS plugin.

The configuration has been updated to use `@tailwindcss/postcss` as indicated by the error message you saw when running the Vite development server. This aligns with the required setup for using Tailwind CSS v4 with PostCSS explicitly.

The `postcss.config.js` now contains:
export default {
  plugins: {
    '@tailwindcss/postcss': {},
    autoprefixer: {},
  },
};