### PR TITLE
Fix: Prevent TopicPageLayout AppBar from overlapping main sidebar

### DIFF
--- a/system-design-study-app/src/components/common/TopicPageLayout.jsx
+++ b/system-design-study-app/src/components/common/TopicPageLayout.jsx
@@ -85,9 +85,11 @@ Consider performance, scalability, and cost implications of your choices.`;
     <Box sx={{ display: 'flex' }}>
       <CssBaseline /> {/* Ensures consistent baseline styling from MUI */}
       <AppBar
-        position="fixed"
+        position="sticky"
         sx={(theme) => ({
           width: '100%', // Changed: AppBar takes full width of its container from Layout.jsx
+          top: 0,
+          zIndex: theme.zIndex.appBar,
           // ml: { sm: `${drawerWidth}px` }, // REMOVED: No longer offset by topic sidebar
           backgroundColor: alpha(theme.palette.background.default, 0.85),
           backdropFilter: 'blur(8px)',


### PR DESCRIPTION
The AppBar within TopicPageLayout was previously using `position: fixed` and `width: 100%` (of viewport), causing it to overlap the main application sidebar when TopicPageLayout was rendered.

This commit changes the AppBar's styling in TopicPageLayout.jsx to use `position: sticky`, `top: 0`, and an appropriate `zIndex`. This makes the AppBar stick to the top of its container (the content area allocated to TopicPageLayout by the main Layout component), rather than being fixed to the viewport.

This ensures that pages utilizing TopicPageLayout (e.g., Caching Strategies, Database Selection) now render correctly within their designated space, without their internal AppBar or content obscuring the main navigation sidebar. Pages not using TopicPageLayout are unaffected.