### PR TITLE
fix: Add fallbacks to muiThemes, revert App.css @apply for debugging

### DIFF
--- a/system-design-study-app/src/App.css
+++ b/system-design-study-app/src/App.css
@@ -1,10 +1,14 @@
 #root {
-  @apply max-w-screen-xl mx-auto p-8 text-center;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+  /* @apply max-w-screen-xl mx-auto p-8 text-center; */
 }
 
 .logo {
-  height: 6em; /* Keep height as is, only padding was specified for change */
-  @apply p-6; /* 1.5em = 24px = spacing-6 */
+  height: 6em;
+  padding: 1.5em; /* Restored from @apply p-6; */
   will-change: filter;
   transition: filter 300ms;
 }
@@ -31,9 +35,9 @@
 }
 
 .card {
-  @apply p-8; /* 2em = 32px = spacing-8 */
+  padding: 2em; /* Restored from @apply p-8; */
 }
 
 .read-the-docs {
-  @apply text-neutral-400; /* #888 mapped to neutral-400 */
+  color: #888; /* Restored from @apply text-neutral-400; */
 }

--- a/system-design-study-app/src/styles/muiThemes.js
+++ b/system-design-study-app/src/styles/muiThemes.js
@@ -1,31 +1,17 @@
 import { createTheme } from '@mui/material/styles';
-// Removed: import resolveConfig from 'tailwindcss/resolveConfig';
-import tailwindConfigRaw from '../../tailwind.config.js'; // Adjusted path
+import tailwindConfigRaw from '../../tailwind.config.js';
 
-// Use the 'extend' part of the Tailwind config directly
-// const fullConfig = resolveConfig(tailwindConfigRaw); // Removed
-const twTheme = tailwindConfigRaw.theme.extend; // Changed to access extend directly
+// Defensively define twTheme
+const twTheme = tailwindConfigRaw && tailwindConfigRaw.theme ? tailwindConfigRaw.theme : {};
 
-// Common typography and component overrides can be defined here
+// Common typography and component overrides
 const commonThemeOptions = {
   typography: {
-    fontFamily: twTheme.fontFamily.sans.join(','), // Use sans-serif stack from Tailwind extend
-    // Example: Define h1-h6 styles if needed, or keep MUI defaults
-    // h1: { fontSize: '2.5rem', fontWeight: 700 },
+    fontFamily: (twTheme.fontFamily && twTheme.fontFamily.sans ? twTheme.fontFamily.sans.join(',') : 'Arial, sans-serif'),
   },
   shape: {
-    borderRadius: 8, // Slightly more rounded than default MUI
+    borderRadius: 8,
   },
-  // You can override component defaults here too
-  // components: {
-  //   MuiButton: {
-  //     styleOverrides: {
-  //       root: {
-  //         textTransform: 'none', // Example: disable uppercase buttons
-  //       },
-  //     },
-  //   },
-  // },
 };
 
 // Light Theme
@@ -34,31 +20,31 @@ export const lightTheme = createTheme({
   palette: {
     mode: 'light',
     primary: {
-      main: twTheme.colors.primary.DEFAULT,
-      light: twTheme.colors.primary.light,
-      dark: twTheme.colors.primary.dark,
+      main: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.DEFAULT ? twTheme.colors.primary.DEFAULT : '#1976D2'),
+      light: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.light ? twTheme.colors.primary.light : '#4791db'),
+      dark: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.dark ? twTheme.colors.primary.dark : '#135ea7'),
     },
     secondary: {
-      main: twTheme.colors.secondary.DEFAULT,
-      light: twTheme.colors.secondary.light,
-      dark: twTheme.colors.secondary.dark,
+      main: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.DEFAULT ? twTheme.colors.secondary.DEFAULT : '#f59e0b'),
+      light: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.light ? twTheme.colors.secondary.light : '#fbbf24'),
+      dark: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.dark ? twTheme.colors.secondary.dark : '#d97706'),
     },
     error: {
-      main: twTheme.colors.error.DEFAULT, // Adjusted path for error color
+      main: (twTheme.colors && twTheme.colors.error && twTheme.colors.error.DEFAULT ? twTheme.colors.error.DEFAULT : '#ef4444'),
     },
-    warning: {
-      main: twTheme.colors.warning, // Assuming warning is still a direct value
+    warning: { // Assuming warning is a direct value, not an object with DEFAULT
+      main: (twTheme.colors && twTheme.colors.warning ? twTheme.colors.warning : '#f97316'),
     },
-    success: {
-      main: twTheme.colors.success, // Assuming success is still a direct value
+    success: { // Assuming success is a direct value
+      main: (twTheme.colors && twTheme.colors.success ? twTheme.colors.success : '#22c55e'),
     },
     background: {
-      default: twTheme.colors.neutral[100],
-      paper: twTheme.colors.neutral[50],
+      default: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[100] ? twTheme.colors.neutral[100] : '#f3f4f6'),
+      paper: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[50] ? twTheme.colors.neutral[50] : '#ffffff'),
     },
     text: {
-      primary: twTheme.colors.neutral[800],
-      secondary: twTheme.colors.neutral[600],
+      primary: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[800] ? twTheme.colors.neutral[800] : '#1f2937'),
+      secondary: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[600] ? twTheme.colors.neutral[600] : '#4b5563'),
     },
   },
 });
@@ -69,31 +55,31 @@ export const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: twTheme.colors.primary.light,
-      light: twTheme.colors.accent.light,
-      dark: twTheme.colors.primary.DEFAULT,
+      main: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.light ? twTheme.colors.primary.light : '#4791db'),
+      light: (twTheme.colors && twTheme.colors.accent && twTheme.colors.accent.light ? twTheme.colors.accent.light : '#73abdf'), // Fallback if accent isn't there either
+      dark: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.DEFAULT ? twTheme.colors.primary.DEFAULT : '#1976D2'),
     },
     secondary: {
-      main: twTheme.colors.secondary.light,
-      light: twTheme.colors.secondary.DEFAULT,
-      dark: twTheme.colors.secondary.DEFAULT,
+      main: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.light ? twTheme.colors.secondary.light : '#fbbf24'),
+      light: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.DEFAULT ? twTheme.colors.secondary.DEFAULT : '#fcd34d'), // original fallback for dark.secondary.light was amber-300
+      dark: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.DEFAULT ? twTheme.colors.secondary.DEFAULT : '#f59e0b'), // original fallback for dark.secondary.dark was amber-500
     },
     error: {
-      main: twTheme.colors.error.DEFAULT, // Adjusted path for error color
+      main: (twTheme.colors && twTheme.colors.error && twTheme.colors.error.DEFAULT ? twTheme.colors.error.DEFAULT : '#ef4444'),
     },
-    warning: {
-      main: twTheme.colors.warning, // Assuming warning is still a direct value
+    warning: { // Assuming warning is a direct value
+      main: (twTheme.colors && twTheme.colors.warning ? twTheme.colors.warning : '#f97316'),
     },
-    success: {
-      main: twTheme.colors.success, // Assuming success is still a direct value
+    success: { // Assuming success is a direct value
+      main: (twTheme.colors && twTheme.colors.success ? twTheme.colors.success : '#22c55e'),
     },
     background: {
-      default: twTheme.colors.neutral[900],
-      paper: twTheme.colors.neutral[800],
+      default: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[900] ? twTheme.colors.neutral[900] : '#111827'),
+      paper: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[800] ? twTheme.colors.neutral[800] : '#1f2937'),
     },
     text: {
-      primary: twTheme.colors.neutral[100],
-      secondary: twTheme.colors.neutral[300],
+      primary: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[100] ? twTheme.colors.neutral[100] : '#f3f4f6'),
+      secondary: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[300] ? twTheme.colors.neutral[300] : '#d1d5db'),
     },
   },
 });


### PR DESCRIPTION
- I've added defensive checks and fallback values in muiThemes.js to make MUI theme generation more resilient in case Tailwind theme values are not resolving as expected.
- I've temporarily reverted @apply rules in App.css to their original direct CSS definitions to help isolate the 'white page' issue.

These changes are intended to help me diagnose why the page is rendering as blank.