### PR TITLE
refactor: Temporarily comment out plugins in tailwind.config.js

### DIFF
--- a/system-design-study-app/tailwind.config.js
+++ b/system-design-study-app/tailwind.config.js
@@ -77,8 +77,8 @@ export default {
       },
     },
   },
-  plugins: [
-    require('@tailwindcss/typography'), // Recommended for prose styling
-    // Add other plugins if you have them
-  ],
+  // plugins: [
+  //   require('@tailwindcss/typography'), // Recommended for prose styling
+  //   // Add other plugins if you have them
+  // ],
 }


### PR DESCRIPTION
I commented out the plugins array in tailwind.config.js to test if the require('@tailwindcss/typography') call was causing issues when the config is imported into muiThemes.js in Vite.

muiThemes.js still imports the config and assigns twTheme, but uses hardcoded values for the actual MUI theme properties for this test.