### PR TITLE
feat: Decouple theme tokens for MUI and Tailwind

### DIFF
--- a/system-design-study-app/src/styles/muiThemes.js
+++ b/system-design-study-app/src/styles/muiThemes.js
@@ -1,13 +1,14 @@
 import { createTheme } from '@mui/material/styles';
-import tailwindConfigRaw from '../../tailwind.config.js';
+// import tailwindConfigRaw from '../../tailwind.config.js'; // Removed
+import { colors, fontFamily } from './themeTokens.js'; // Added fontSize, spacing if needed later
 
-// Defensively define twTheme
-const twTheme = tailwindConfigRaw && tailwindConfigRaw.theme ? tailwindConfigRaw.theme : {};
+// Defensively define twTheme // Removed
+// const twTheme = tailwindConfigRaw && tailwindConfigRaw.theme ? tailwindConfigRaw.theme : {};
 
 // Common typography and component overrides
 const commonThemeOptions = {
   typography: {
-    fontFamily: (twTheme.fontFamily && twTheme.fontFamily.sans ? twTheme.fontFamily.sans.join(',') : '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'),
+    fontFamily: (fontFamily && fontFamily.sans ? fontFamily.sans.join(',') : '"Inter", "Roboto", "Helvetica", "Arial", sans-serif'),
   },
   shape: {
     borderRadius: 8,
@@ -20,31 +21,31 @@ export const lightTheme = createTheme({
   palette: {
     mode: 'light',
     primary: {
-      main: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.DEFAULT ? twTheme.colors.primary.DEFAULT : '#1976D2'),
-      light: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.light ? twTheme.colors.primary.light : '#4791db'),
-      dark: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.dark ? twTheme.colors.primary.dark : '#135ea7'),
+      main: (colors && colors.primary && colors.primary.DEFAULT ? colors.primary.DEFAULT : '#1976D2'),
+      light: (colors && colors.primary && colors.primary.light ? colors.primary.light : '#4791db'),
+      dark: (colors && colors.primary && colors.primary.dark ? colors.primary.dark : '#135ea7'),
     },
     secondary: {
-      main: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.DEFAULT ? twTheme.colors.secondary.DEFAULT : '#f59e0b'),
-      light: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.light ? twTheme.colors.secondary.light : '#fbbf24'),
-      dark: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.dark ? twTheme.colors.secondary.dark : '#d97706'),
+      main: (colors && colors.secondary && colors.secondary.DEFAULT ? colors.secondary.DEFAULT : '#f59e0b'),
+      light: (colors && colors.secondary && colors.secondary.light ? colors.secondary.light : '#fbbf24'),
+      dark: (colors && colors.secondary && colors.secondary.dark ? colors.secondary.dark : '#d97706'),
     },
     error: {
-      main: (twTheme.colors && twTheme.colors.error && twTheme.colors.error.DEFAULT ? twTheme.colors.error.DEFAULT : '#ef4444'),
+      main: (colors && colors.error && colors.error.DEFAULT ? colors.error.DEFAULT : '#ef4444'),
     },
     warning: {
-      main: (twTheme.colors && twTheme.colors.warning ? twTheme.colors.warning : '#f97316'),
+      main: (colors && colors.warning ? colors.warning : '#f97316'),
     },
     success: {
-      main: (twTheme.colors && twTheme.colors.success ? twTheme.colors.success : '#22c55e'),
+      main: (colors && colors.success ? colors.success : '#22c55e'),
     },
     background: {
-      default: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[100] ? twTheme.colors.neutral[100] : '#f3f4f6'),
-      paper: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[50] ? twTheme.colors.neutral[50] : '#ffffff'),
+      default: (colors && colors.neutral && colors.neutral[100] ? colors.neutral[100] : '#f3f4f6'),
+      paper: (colors && colors.neutral && colors.neutral[50] ? colors.neutral[50] : '#ffffff'),
     },
     text: {
-      primary: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[800] ? twTheme.colors.neutral[800] : '#1f2937'),
-      secondary: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[600] ? twTheme.colors.neutral[600] : '#4b5563'),
+      primary: (colors && colors.neutral && colors.neutral[800] ? colors.neutral[800] : '#1f2937'),
+      secondary: (colors && colors.neutral && colors.neutral[600] ? colors.neutral[600] : '#4b5563'),
     },
   },
 });
@@ -55,31 +56,31 @@ export const darkTheme = createTheme({
   palette: {
     mode: 'dark',
     primary: {
-      main: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.light ? twTheme.colors.primary.light : '#4791db'),
-      light: (twTheme.colors && twTheme.colors.accent && twTheme.colors.accent.light ? twTheme.colors.accent.light : '#73abdf'),
-      dark: (twTheme.colors && twTheme.colors.primary && twTheme.colors.primary.DEFAULT ? twTheme.colors.primary.DEFAULT : '#1976D2'),
+      main: (colors && colors.primary && colors.primary.light ? colors.primary.light : '#4791db'),
+      light: (colors && colors.accent && colors.accent.light ? colors.accent.light : '#73abdf'),
+      dark: (colors && colors.primary && colors.primary.DEFAULT ? colors.primary.DEFAULT : '#1976D2'),
     },
     secondary: {
-      main: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.light ? twTheme.colors.secondary.light : '#fbbf24'),
-      light: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.DEFAULT ? twTheme.colors.secondary.DEFAULT : '#fcd34d'),
-      dark: (twTheme.colors && twTheme.colors.secondary && twTheme.colors.secondary.DEFAULT ? twTheme.colors.secondary.DEFAULT : '#f59e0b'),
+      main: (colors && colors.secondary && colors.secondary.light ? colors.secondary.light : '#fbbf24'),
+      light: (colors && colors.secondary && colors.secondary.DEFAULT ? colors.secondary.DEFAULT : '#fcd34d'),
+      dark: (colors && colors.secondary && colors.secondary.DEFAULT ? colors.secondary.DEFAULT : '#f59e0b'),
     },
     error: {
-      main: (twTheme.colors && twTheme.colors.error && twTheme.colors.error.DEFAULT ? twTheme.colors.error.DEFAULT : '#ef4444'),
+      main: (colors && colors.error && colors.error.DEFAULT ? colors.error.DEFAULT : '#ef4444'),
     },
     warning: {
-      main: (twTheme.colors && twTheme.colors.warning ? twTheme.colors.warning : '#f97316'),
+      main: (colors && colors.warning ? colors.warning : '#f97316'),
     },
     success: {
-      main: (twTheme.colors && twTheme.colors.success ? twTheme.colors.success : '#22c55e'),
+      main: (colors && colors.success ? colors.success : '#22c55e'),
     },
     background: {
-      default: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[900] ? twTheme.colors.neutral[900] : '#111827'),
-      paper: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[800] ? twTheme.colors.neutral[800] : '#1f2937'),
+      default: (colors && colors.neutral && colors.neutral[900] ? colors.neutral[900] : '#111827'),
+      paper: (colors && colors.neutral && colors.neutral[800] ? colors.neutral[800] : '#1f2937'),
     },
     text: {
-      primary: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[100] ? twTheme.colors.neutral[100] : '#f3f4f6'),
-      secondary: (twTheme.colors && twTheme.colors.neutral && twTheme.colors.neutral[300] ? twTheme.colors.neutral[300] : '#d1d5db'),
+      primary: (colors && colors.neutral && colors.neutral[100] ? colors.neutral[100] : '#f3f4f6'),
+      secondary: (colors && colors.neutral && colors.neutral[300] ? colors.neutral[300] : '#d1d5db'),
     },
   },
 });

--- a/system-design-study-app/src/styles/themeTokens.js
+++ b/system-design-study-app/src/styles/themeTokens.js
@@ -1,0 +1,74 @@
+// system-design-study-app/src/styles/themeTokens.js
+
+export const colors = {
+  primary: {
+    light: '#4791db',
+    DEFAULT: '#1976D2',
+    dark: '#135ea7',
+  },
+  secondary: {
+    light: '#fbbf24',
+    DEFAULT: '#f59e0b',
+    dark: '#d97706',
+  },
+  accent: {
+    light: '#67e8f9',
+    DEFAULT: '#06b6d4',
+    dark: '#0e7490',
+  },
+  neutral: {
+    50: '#f8fafc',
+    100: '#f1f5f9',
+    200: '#e2e8f0',
+    300: '#cbd5e1',
+    400: '#94a3b8',
+    500: '#64748b',
+    600: '#475569',
+    700: '#334155',
+    800: '#1e293b',
+    900: '#0f172a',
+  },
+  success: '#22c55e',
+  error: {
+    DEFAULT: '#ef4444',
+    dark: '#d92626',
+  },
+  warning: '#f97316',
+};
+
+export const fontFamily = {
+  sans: ['Inter', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'],
+};
+
+export const fontSize = {
+  'caption': ['0.75rem', { lineHeight: '1rem' }],
+  'body': ['1rem', { lineHeight: '1.5rem' }],
+  'h3': ['1.5rem', { lineHeight: '2rem' }],
+  'h2': ['1.875rem', { lineHeight: '2.25rem' }],
+  'h1': ['2.25rem', { lineHeight: '2.5rem' }],
+};
+
+export const spacing = {
+  'spacing-0': '0px',
+  'spacing-1': '0.25rem',
+  'spacing-2': '0.5rem',
+  'spacing-3': '0.75rem',
+  'spacing-4': '1rem',
+  'spacing-5': '1.25rem',
+  'spacing-6': '1.5rem',
+  'spacing-7': '1.75rem',
+  'spacing-8': '2rem',
+  'spacing-9': '2.25rem',
+  'spacing-10': '2.5rem',
+  'spacing-11': '2.75rem',
+  'spacing-12': '3rem',
+  'spacing-14': '3.5rem',
+  'spacing-16': '4rem',
+  'spacing-20': '5rem',
+  'spacing-24': '6rem',
+  '1.5': '0.375rem',
+};
+
+// It might be good to also export a combined 'theme' object for easier consumption
+// if muiThemes.js was structured to expect twTheme.colors, twTheme.fontFamily etc.
+// For now, exporting them separately as per the plan.

--- a/system-design-study-app/tailwind.config.js
+++ b/system-design-study-app/tailwind.config.js
@@ -1,4 +1,6 @@
 /** @type {import('tailwindcss').Config} */
+import { colors, fontFamily, fontSize, spacing } from './src/styles/themeTokens.js';
+
 export default {
   content: [
     "./index.html", // Path to your main HTML file
@@ -7,78 +9,13 @@ export default {
   darkMode: 'class', // Ensure dark mode is class-based
   theme: {
     extend: {
-      colors: {
-        primary: {
-          light: '#4791db', // Lighter shade of #1976D2
-          DEFAULT: '#1976D2', // Core primary color
-          dark: '#135ea7',  // Darker shade of #1976D2
-        },
-        secondary: {
-          light: '#fbbf24', // amber-400
-          DEFAULT: '#f59e0b', // amber-500
-          dark: '#d97706',  // amber-600
-        },
-        accent: {
-          light: '#67e8f9', // Lighter teal/cyan
-          DEFAULT: '#06b6d4', // Teal/cyan
-          dark: '#0e7490',  // Darker teal/cyan
-        },
-        neutral: {
-          50: '#f8fafc',
-          100: '#f1f5f9',
-          200: '#e2e8f0',
-          300: '#cbd5e1',
-          400: '#94a3b8',
-          500: '#64748b',
-          600: '#475569',
-          700: '#334155',
-          800: '#1e293b',
-          900: '#0f172a',
-        },
-        success: '#22c55e',
-        error: {
-          DEFAULT: '#ef4444',
-          dark: '#d92626', // For hover states, darker shade
-        },
-        warning: '#f97316',
-      },
-      fontFamily: {
-        sans: ['Inter', 'Roboto', 'Helvetica', 'Arial', 'sans-serif'],
-      },
-      fontSize: {
-        // Tailwind's existing xs, sm, base, lg, xl will be inherited
-        // We are adding new ones and explicitly defining some that might overlap
-        // but with specific line heights as per the design.
-        'caption': ['0.75rem', { lineHeight: '1rem' }], // 12px
-        'body': ['1rem', { lineHeight: '1.5rem' }],    // 16px (same as base)
-        'h3': ['1.5rem', { lineHeight: '2rem' }],      // 24px (Tailwind's 2xl)
-        'h2': ['1.875rem', { lineHeight: '2.25rem' }],// 30px (Tailwind's 3xl)
-        'h1': ['2.25rem', { lineHeight: '2.5rem' }],  // 36px (Tailwind's 4xl)
-      },
-      spacing: {
-        'spacing-0': '0px',
-        'spacing-1': '0.25rem',    // 4px
-        'spacing-2': '0.5rem',     // 8px
-        'spacing-3': '0.75rem',    // 12px
-        'spacing-4': '1rem',       // 16px
-        'spacing-5': '1.25rem',    // 20px
-        'spacing-6': '1.5rem',     // 24px
-        'spacing-7': '1.75rem',    // 28px
-        'spacing-8': '2rem',       // 32px
-        'spacing-9': '2.25rem',    // 36px
-        'spacing-10': '2.5rem',    // 40px
-        'spacing-11': '2.75rem',   // 44px
-        'spacing-12': '3rem',      // 48px
-        'spacing-14': '3.5rem',    // 56px
-        'spacing-16': '4rem',      // 64px
-        'spacing-20': '5rem',      // 80px
-        'spacing-24': '6rem',      // 96px
-        '1.5': '0.375rem',         // 6px (for py-1.5)
-      },
-    },
+      colors: colors,
+      fontFamily: fontFamily,
+      fontSize: fontSize,
+      spacing: spacing,
+    }
   },
-  // plugins: [
-  //   require('@tailwindcss/typography'), // Recommended for prose styling
-  //   // Add other plugins if you have them
-  // ],
+  plugins: [
+    require('@tailwindcss/typography'),
+  ],
 }


### PR DESCRIPTION
I introduced a new `themeTokens.js` file to store shared design tokens (colors, fontFamily, fontSize, spacing).

- `tailwind.config.js` now imports its theme configuration from `themeTokens.js` and has its plugins (e.g., typography) re-enabled.
- `muiThemes.js` also imports its theme configuration directly from `themeTokens.js`, avoiding the need to import the full `tailwind.config.js` which caused issues with Vite due to `require()` calls in plugins.

This approach allows both Tailwind (via PostCSS) and MUI (via JS) to use the same source of truth for design tokens without import conflicts, resolving the blank page issue.