### PR TITLE
refactor: Revert index.css to use @import "tailwindcss"

### DIFF
--- a/system-design-study-app/src/index.css
+++ b/system-design-study-app/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 @variant dark (&:where(.dark, .dark *));
 


### PR DESCRIPTION
Reverted src/index.css from explicit @tailwind directives back to using @import "tailwindcss"; to see if this restores base layout styling.

This is part of debugging why the page appeared unstyled. muiThemes.js still has local tokens and a magenta fallback for primary.main for this test.