### PR TITLE
feat: Add prominent test div with inline styles to App.jsx

### DIFF
--- a/system-design-study-app/src/App.jsx
+++ b/system-design-study-app/src/App.jsx
@@ -24,6 +24,19 @@ function AppContent() {
   return (
     <MuiThemeProvider theme={muiTheme}>
       <CssBaseline /> {/* Normalizes styles and applies MUI's dark background in dark mode */}
+      <div style={{
+        color: 'red',
+        backgroundColor: 'lightyellow',
+        padding: '10px',
+        fontSize: '20px',
+        border: '2px solid blue',
+        position: 'fixed', // Make it very obvious
+        top: '10px',
+        left: '10px',
+        zIndex: 9999
+      }}>
+        THIS IS A TEST DIV - Can you see colors?
+      </div>
       <Router>
         <Layout> {/* Layout now has access to AuthContext and benefits from MuiThemeProvider */}
           <Routes>


### PR DESCRIPTION
I've added a div with fixed positioning and bright inline styles (red text, lightyellow background, blue border) to App.jsx.

This is to test if the browser can render basic CSS colors and styles at all, as part of diagnosing your 'no color' issue.

muiThemes.js remains drastically simplified (hardcoded green/yellow primary colors) and themeTokens.js remains minimal for this test.