### PR TITLE
Here's the refactor I've made:

### DIFF
--- a/system-design-study-app/src/App.jsx
+++ b/system-design-study-app/src/App.jsx
@@ -21,22 +21,14 @@ function AppContent() {
   const { themeMode } = useCustomTheme(); // Custom hook for light/dark mode state
   const muiTheme = themeMode === 'dark' ? darkTheme : lightTheme;
 
+  console.log('App.jsx: Imported lightTheme from muiThemes:', lightTheme);
+  console.log('App.jsx: Imported darkTheme from muiThemes:', darkTheme);
+  console.log('App.jsx: Current themeMode:', themeMode);
+  console.log('App.jsx: Chosen muiTheme for MuiThemeProvider:', muiTheme);
+
   return (
     <MuiThemeProvider theme={muiTheme}>
       <CssBaseline /> {/* Normalizes styles and applies MUI's dark background in dark mode */}
-      <div style={{
-        color: 'red',
-        backgroundColor: 'lightyellow',
-        padding: '10px',
-        fontSize: '20px',
-        border: '2px solid blue',
-        position: 'fixed', // Make it very obvious
-        top: '10px',
-        left: '10px',
-        zIndex: 9999
-      }}>
-        THIS IS A TEST DIV - Can you see colors?
-      </div>
       <Router>
         <Layout> {/* Layout now has access to AuthContext and benefits from MuiThemeProvider */}
           <Routes>

--- a/system-design-study-app/src/styles/muiThemes.js
+++ b/system-design-study-app/src/styles/muiThemes.js
@@ -3,7 +3,7 @@ import { createTheme } from '@mui/material/styles';
 
 // Remove all local 'colors', 'fontFamily' consts and imports from 'themeTokens.js'
 
-export const lightTheme = createTheme({
+const lightThemeObj = createTheme({
   palette: {
     mode: 'light',
     primary: {
@@ -28,8 +28,10 @@ export const lightTheme = createTheme({
     borderRadius: 8,
   }
 });
+console.log('muiThemes.js: lightTheme object:', lightThemeObj);
+export const lightTheme = lightThemeObj;
 
-export const darkTheme = createTheme({
+const darkThemeObj = createTheme({
   palette: {
     mode: 'dark',
     primary: {
@@ -54,3 +56,5 @@ export const darkTheme = createTheme({
     borderRadius: 8,
   }
 });
+console.log('muiThemes.js: darkTheme object:', darkThemeObj);
+export const darkTheme = darkThemeObj;


### PR DESCRIPTION
- I've added console.log statements in muiThemes.js and App.jsx. This will allow you to inspect the MUI theme objects when they are defined and used.
- I've also removed the temporary inline-styled test div from App.jsx.

This should help you gather more information on why the MUI themes (which are currently simplified and hardcoded as green/yellow) might not be applying correctly.