### PR TITLE
feat: Implement Tailwind prefix to prevent CSS conflicts

### DIFF
--- a/system-design-study-app/src/index.css
+++ b/system-design-study-app/src/index.css
@@ -5,7 +5,7 @@
 @layer base {
   body {
     font-family: 'Inter', sans-serif;
-    @apply bg-neutral-100 dark:bg-neutral-900 text-neutral-800 dark:text-neutral-200;
+    @apply tw-bg-neutral-100 dark:tw-bg-neutral-900 tw-text-neutral-800 dark:tw-text-neutral-200;
     /* Smoother font rendering */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/system-design-study-app/src/main.jsx
+++ b/system-design-study-app/src/main.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
-// import './index.css' // Tailwind directives
+import './index.css' // Tailwind directives
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/system-design-study-app/tailwind.config.js
+++ b/system-design-study-app/tailwind.config.js
@@ -7,6 +7,7 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx,vue}", // Path to all relevant source files
   ],
   darkMode: 'class', // Ensure dark mode is class-based
+  prefix: 'tw-', // Added Tailwind prefix
   theme: {
     extend: {
       colors: themeTokens.colors,


### PR DESCRIPTION
Added `prefix: 'tw-'` to tailwind.config.js and updated @apply rules in index.css for body styles to use these prefixed classes.

This is to prevent Tailwind's utility classes from conflicting with MUI's default component styles, with the goal of allowing MUI components to correctly adopt their theme colors.

muiThemes.js still uses simplified hardcoded themes for this test.