### PR TITLE
refactor: Revert Tailwind prefix strategy

### DIFF
--- a/system-design-study-app/src/index.css
+++ b/system-design-study-app/src/index.css
@@ -5,7 +5,7 @@
 @layer base {
   body {
     font-family: 'Inter', sans-serif;
-    @apply tw-bg-neutral-100 dark:tw-bg-neutral-900 tw-text-neutral-800 dark:tw-text-neutral-200;
+    @apply bg-neutral-100 dark:bg-neutral-900 text-neutral-800 dark:text-neutral-200;
     /* Smoother font rendering */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/system-design-study-app/tailwind.config.js
+++ b/system-design-study-app/tailwind.config.js
@@ -7,7 +7,6 @@ export default {
     "./src/**/*.{js,ts,jsx,tsx,vue}", // Path to all relevant source files
   ],
   darkMode: 'class', // Ensure dark mode is class-based
-  prefix: 'tw-', // Added Tailwind prefix
   theme: {
     extend: {
       colors: themeTokens.colors,


### PR DESCRIPTION
- Removed `prefix: 'tw-'` from tailwind.config.js.
- Reverted prefixed @apply rules in index.css body style to non-prefixed.

This is to restore base Tailwind styling and page structure, as the prefix strategy inadvertently broke Tailwind's CSS application. Further investigation into MUI component theming will follow.