### PR TITLE
Fix: Resolve icon loading and HTML nesting errors

### DIFF
--- a/system-design-study-app/src/components/databases/SectionDocumentDB.jsx
+++ b/system-design-study-app/src/components/databases/SectionDocumentDB.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button'; // Import Button
-import Icon from '../common/Icon';   // Import Icon
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) => {
     const isOpen = idx === openIdx;
@@ -21,7 +22,7 @@ const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) 
                 aria-expanded={isOpen}
             >
                 <span>{title}</span>
-                <Icon name={isOpen ? "chevron-up" : "chevron-down"} className="h-5 w-5" />
+                {isOpen ? <KeyboardArrowUpIcon className="h-5 w-5" /> : <KeyboardArrowDownIcon className="h-5 w-5" />}
             </Button>
             {isOpen && (
                 <div className={`p-4 pt-2 text-sm text-neutral-600 dark:text-neutral-300 bg-white dark:bg-neutral-700/30 ${lastItem ? 'rounded-b-lg' : 'border-b border-neutral-200 dark:border-neutral-600/70'}`}>

--- a/system-design-study-app/src/components/databases/SectionGraphDB.jsx
+++ b/system-design-study-app/src/components/databases/SectionGraphDB.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button'; // Import Button
-import Icon from '../common/Icon';   // Import Icon
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) => {
     const isOpen = idx === openIdx;
@@ -21,7 +22,7 @@ const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) 
                 aria-expanded={isOpen}
             >
                 <span>{title}</span>
-                <Icon name={isOpen ? "chevron-up" : "chevron-down"} className="h-5 w-5" />
+                {isOpen ? <KeyboardArrowUpIcon className="h-5 w-5" /> : <KeyboardArrowDownIcon className="h-5 w-5" />}
             </Button>
             {isOpen && (
                 <div className={`p-4 pt-2 text-sm text-neutral-600 dark:text-neutral-300 bg-white dark:bg-neutral-700/30 ${lastItem ? 'rounded-b-lg' : 'border-b border-neutral-200 dark:border-neutral-600/70'}`}>

--- a/system-design-study-app/src/components/databases/SectionKeyValueDB.jsx
+++ b/system-design-study-app/src/components/databases/SectionKeyValueDB.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button'; // Import Button
-import Icon from '../common/Icon';   // Import Icon
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 // AccordionItem (Assuming it might be slightly different or want to keep it co-located for now)
 // If identical to SectionSqlDB's, this could be moved to a common component.
@@ -23,7 +24,7 @@ const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) 
                 aria-expanded={isOpen}
             >
                 <span>{title}</span>
-                <Icon name={isOpen ? "chevron-up" : "chevron-down"} className="h-5 w-5" />
+                {isOpen ? <KeyboardArrowUpIcon className="h-5 w-5" /> : <KeyboardArrowDownIcon className="h-5 w-5" />}
             </Button>
             {isOpen && (
                 <div className={`p-4 pt-2 text-sm text-neutral-600 dark:text-neutral-300 bg-white dark:bg-neutral-700/30 ${lastItem ? 'rounded-b-lg' : 'border-b border-neutral-200 dark:border-neutral-600/70'}`}>

--- a/system-design-study-app/src/components/databases/SectionPolyglotDB.jsx
+++ b/system-design-study-app/src/components/databases/SectionPolyglotDB.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button'; // Import Button
-import Icon from '../common/Icon';   // Import Icon
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) => {
     const isOpen = idx === openIdx;
@@ -21,7 +22,7 @@ const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) 
                 aria-expanded={isOpen}
             >
                 <span>{title}</span>
-                <Icon name={isOpen ? "chevron-up" : "chevron-down"} className="h-5 w-5" />
+                {isOpen ? <KeyboardArrowUpIcon className="h-5 w-5" /> : <KeyboardArrowDownIcon className="h-5 w-5" />}
             </Button>
             {isOpen && (
                 <div className={`p-4 pt-2 text-sm text-neutral-600 dark:text-neutral-300 bg-white dark:bg-neutral-700/30 ${lastItem ? 'rounded-b-lg' : 'border-b border-neutral-200 dark:border-neutral-600/70'}`}>

--- a/system-design-study-app/src/components/databases/SectionSearchDB.jsx
+++ b/system-design-study-app/src/components/databases/SectionSearchDB.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button'; // Import Button
-import Icon from '../common/Icon';   // Import Icon
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) => {
     const isOpen = idx === openIdx;
@@ -21,7 +22,7 @@ const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) 
                 aria-expanded={isOpen}
             >
                 <span>{title}</span>
-                <Icon name={isOpen ? "chevron-up" : "chevron-down"} className="h-5 w-5" />
+                {isOpen ? <KeyboardArrowUpIcon className="h-5 w-5" /> : <KeyboardArrowDownIcon className="h-5 w-5" />}
             </Button>
             {isOpen && (
                 <div className={`p-4 pt-2 text-sm text-neutral-600 dark:text-neutral-300 bg-white dark:bg-neutral-700/30 ${lastItem ? 'rounded-b-lg' : 'border-b border-neutral-200 dark:border-neutral-600/70'}`}>

--- a/system-design-study-app/src/components/databases/SectionSqlDB.jsx
+++ b/system-design-study-app/src/components/databases/SectionSqlDB.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button';
-import Icon from '../common/Icon';   // Import Icon
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 // AccordionItem Component (can be moved to a common components folder if used elsewhere)
 const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) => {
@@ -22,7 +23,7 @@ const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) 
                 aria-expanded={isOpen}
             >
                 <span className="text-lg">{title}</span>
-                <Icon name={isOpen ? "chevron-up" : "chevron-down"} className="h-5 w-5" />
+                {isOpen ? <KeyboardArrowUpIcon className="h-5 w-5" /> : <KeyboardArrowDownIcon className="h-5 w-5" />}
             </Button>
             {isOpen && (
                 <div className={`p-5 text-base text-neutral-600 dark:text-neutral-300 bg-white dark:bg-neutral-700/30 ${lastItem ? 'rounded-b-lg' : 'border-b border-neutral-300 dark:border-neutral-600'}`}>

--- a/system-design-study-app/src/components/databases/SectionWideColumnDB.jsx
+++ b/system-design-study-app/src/components/databases/SectionWideColumnDB.jsx
@@ -2,7 +2,8 @@
 import React, { useState } from 'react';
 import Card from '../common/Card';
 import Button from '../common/Button'; // Import Button
-import Icon from '../common/Icon';   // Import Icon
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 
 const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) => {
     const isOpen = idx === openIdx;
@@ -21,7 +22,7 @@ const AccordionItem = ({ title, children, idx, openIdx, setOpenIdx, lastItem }) 
                 aria-expanded={isOpen}
             >
                 <span>{title}</span>
-                <Icon name={isOpen ? "chevron-up" : "chevron-down"} className="h-5 w-5" />
+                {isOpen ? <KeyboardArrowUpIcon className="h-5 w-5" /> : <KeyboardArrowDownIcon className="h-5 w-5" />}
             </Button>
             {isOpen && (
                 <div className={`p-4 pt-2 text-sm text-neutral-600 dark:text-neutral-300 bg-white dark:bg-neutral-700/30 ${lastItem ? 'rounded-b-lg' : 'border-b border-neutral-200 dark:border-neutral-600/70'}`}>

--- a/system-design-study-app/src/components/loadbalancing/TypesView.jsx
+++ b/system-design-study-app/src/components/loadbalancing/TypesView.jsx
@@ -26,9 +26,11 @@ function TypesView({ appData }) {
                   primary={<strong>Description:</strong>}
                   secondary={lbType.description}
                   sx={{ mb: 1 }}
+                  secondaryTypographyProps={{ component: 'div' }}
                 />
                 <ListItemText
                   primary={<strong>Pros:</strong>}
+                  secondaryTypographyProps={{ component: 'div' }}
                   secondary={
                     <List dense disablePadding>
                       {lbType.pros.map((pro, index) => (
@@ -42,6 +44,7 @@ function TypesView({ appData }) {
                 />
                 <ListItemText
                   primary={<strong>Cons:</strong>}
+                  secondaryTypographyProps={{ component: 'div' }}
                   secondary={
                     <List dense disablePadding>
                       {lbType.cons.map((con, index) => (
@@ -56,6 +59,7 @@ function TypesView({ appData }) {
                 <ListItemText
                   primary={<strong>Use Cases:</strong>}
                   secondary={lbType.useCases}
+                  secondaryTypographyProps={{ component: 'div' }}
                 />
               </ListItem>
               <Divider component="li" sx={{ mb: 2 }} />


### PR DESCRIPTION
- Replaced missing chevron icons with Material UI KeyboardArrowUp/Down icons in database section components to fix dynamic import errors.
- Corrected HTML nesting in TypesView.jsx by changing the secondary prop of ListItemText to render as a div, preventing p tags from wrapping lists and other block elements, which resolved hydration warnings.