### PR TITLE
Fix: Address nesting, reference, and Mermaid errors; add tests

### DIFF
--- a/system-design-study-app/src/components/apidesign/ProtocolsView.jsx
+++ b/system-design-study-app/src/components/apidesign/ProtocolsView.jsx
@@ -22,9 +22,11 @@ function ProtocolsView({ appData }) {
                   primary={<strong>Structure / Key Characteristics:</strong>}
                   secondary={protocol.structure}
                   sx={{ mb: 1 }}
+                  secondaryTypographyProps={{ component: 'div' }}
                 />
                 <ListItemText
                   primary={<strong>Pros:</strong>}
+                  secondaryTypographyProps={{ component: 'div' }}
                   secondary={
                     <List dense disablePadding>
                       {protocol.pros.map((pro, index) => (
@@ -38,6 +40,7 @@ function ProtocolsView({ appData }) {
                 />
                 <ListItemText
                   primary={<strong>Cons:</strong>}
+                  secondaryTypographyProps={{ component: 'div' }}
                   secondary={
                     <List dense disablePadding>
                       {protocol.cons.map((con, index) => (
@@ -52,6 +55,7 @@ function ProtocolsView({ appData }) {
                 <ListItemText
                   primary={<strong>Common Use Cases:</strong>}
                   secondary={protocol.useCases}
+                  secondaryTypographyProps={{ component: 'div' }}
                 />
               </ListItem>
               <Divider component="li" sx={{ mb: 2 }} />

--- a/system-design-study-app/src/components/apidesign/ProtocolsView.test.jsx
+++ b/system-design-study-app/src/components/apidesign/ProtocolsView.test.jsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ProtocolsView from './ProtocolsView';
+
+describe('ProtocolsView', () => {
+  const mockAppData = {
+    protocols: [
+      {
+        id: 'rest',
+        name: 'REST (Representational State Transfer)',
+        structure: 'Client-server, stateless, cacheable, layered system. Uses HTTP methods (GET, POST, PUT, DELETE).',
+        pros: ['Simple, widely adopted', 'Scalable', 'Flexible (various data formats like JSON, XML)'],
+        cons: ['Can be chatty (multiple requests)', 'Over-fetching/under-fetching data'],
+        useCases: 'Public APIs, web services, mobile app backends.',
+      },
+      {
+        id: 'graphql',
+        name: 'GraphQL',
+        structure: 'Query language for APIs. Clients request exactly the data they need.',
+        pros: ['Solves over-fetching/under-fetching', 'Strongly typed schema', 'Real-time updates with Subscriptions'],
+        cons: ['Complexity in server-side implementation', 'Caching can be more complex than REST'],
+        useCases: 'Mobile apps, complex frontends, applications with diverse data requirements.',
+      },
+    ],
+  };
+
+  const emptyAppData = {
+    protocols: [],
+  };
+
+  const nullAppData = { protocols: null }; // Or simply null, depending on how the component handles it
+  const undefinedAppData = {};
+
+
+  test('renders loading message when appData or appData.protocols is null/undefined', () => {
+    const { rerender } = render(<ProtocolsView appData={nullAppData} />);
+    expect(screen.getByText('Loading API protocol data...')).toBeInTheDocument();
+
+    rerender(<ProtocolsView appData={undefinedAppData} />);
+    expect(screen.getByText('Loading API protocol data...')).toBeInTheDocument();
+  });
+
+  test('renders main title', () => {
+    render(<ProtocolsView appData={mockAppData} />);
+    expect(screen.getByText('API Protocols & Styles')).toBeInTheDocument();
+  });
+
+  test('renders all protocols from appData', () => {
+    render(<ProtocolsView appData={mockAppData} />);
+    expect(screen.getByText('REST (Representational State Transfer)')).toBeInTheDocument();
+    expect(screen.getByText('GraphQL')).toBeInTheDocument();
+  });
+
+  test('renders structure, pros, cons, and use cases for each protocol', () => {
+    render(<ProtocolsView appData={mockAppData} />);
+    const restData = mockAppData.protocols[0];
+    const graphqlData = mockAppData.protocols[1];
+
+    // Check REST data
+    expect(screen.getByText(restData.structure)).toBeInTheDocument();
+    restData.pros.forEach(pro => expect(screen.getByText(pro)).toBeInTheDocument());
+    restData.cons.forEach(con => expect(screen.getByText(con)).toBeInTheDocument());
+    expect(screen.getByText(restData.useCases)).toBeInTheDocument();
+
+    // Check GraphQL data
+    expect(screen.getByText(graphqlData.structure)).toBeInTheDocument();
+    graphqlData.pros.forEach(pro => expect(screen.getByText(pro)).toBeInTheDocument());
+    graphqlData.cons.forEach(con => expect(screen.getByText(con)).toBeInTheDocument());
+    expect(screen.getByText(graphqlData.useCases)).toBeInTheDocument();
+  });
+
+  // The fix for nesting errors was to use secondaryTypographyProps={{ component: 'div' }}
+  // These tests ensure content (including lists for pros/cons) is rendered.
+  // Absence of console warnings during tests would be an indirect confirmation.
+});

--- a/system-design-study-app/src/components/common/InteractiveDecisionTree.test.jsx
+++ b/system-design-study-app/src/components/common/InteractiveDecisionTree.test.jsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import InteractiveDecisionTree from './InteractiveDecisionTree';
+
+// Mock common components
+jest.mock('./Button', () => ({ children, onClick, disabled, className, ...rest }) => (
+  <button data-testid="button" onClick={onClick} disabled={disabled} className={className} {...rest}>
+    {children}
+  </button>
+));
+jest.mock('./Card', () => ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>);
+
+
+const mockTreeData = {
+  title: "Test Decision Tree",
+  startNode: "node1",
+  nodes: {
+    node1: {
+      question: "Is it sunny?",
+      description: "Consider the weather outside.",
+      options: [
+        { answer: "Yes, it is sunny", nextNode: "node2" },
+        { answer: "No, it is not sunny", recommendation: "Stay indoors and read a book." },
+      ],
+    },
+    node2: {
+      question: "Is it warm?",
+      options: [
+        { answer: "Yes, it is warm", recommendation: "Go to the beach!" },
+        { answer: "No, it is cool", recommendation: "Go for a hike." },
+      ],
+    },
+  },
+};
+
+const invalidTreeData = {
+  title: "Invalid Tree",
+  // startNode: "node1", // Missing startNode
+  nodes: {},
+};
+
+const treeDataWithMissingNode = {
+    title: "Missing Node Tree",
+    startNode: "node1",
+    nodes: {
+        // node1 is missing
+        node2: { question: "Some question", options: []}
+    }
+};
+
+
+describe('InteractiveDecisionTree', () => {
+  test('renders error message with invalid treeData (missing startNode)', () => {
+    render(<InteractiveDecisionTree treeData={invalidTreeData} />);
+    expect(screen.getByText('Error: Decision tree data is invalid or missing.')).toBeInTheDocument();
+  });
+
+  test('renders error message if current node is not found', () => {
+    render(<InteractiveDecisionTree treeData={treeDataWithMissingNode} />);
+    expect(screen.getByText("Error: Current node 'node1' not found in tree data.")).toBeInTheDocument();
+  });
+
+  test('renders the initial question and options from startNode', () => {
+    render(<InteractiveDecisionTree treeData={mockTreeData} />);
+    expect(screen.getByText(mockTreeData.title)).toBeInTheDocument();
+    expect(screen.getByText(mockTreeData.nodes.node1.question)).toBeInTheDocument();
+    expect(screen.getByText(mockTreeData.nodes.node1.description)).toBeInTheDocument();
+    mockTreeData.nodes.node1.options.forEach(opt => {
+      expect(screen.getByText(opt.answer)).toBeInTheDocument();
+    });
+  });
+
+  test('navigates to the next node when an option with nextNode is clicked', () => {
+    render(<InteractiveDecisionTree treeData={mockTreeData} />);
+    const yesSunnyButton = screen.getByText("Yes, it is sunny");
+    fireEvent.click(yesSunnyButton);
+
+    expect(screen.getByText(mockTreeData.nodes.node2.question)).toBeInTheDocument();
+    mockTreeData.nodes.node2.options.forEach(opt => {
+      expect(screen.getByText(opt.answer)).toBeInTheDocument();
+    });
+  });
+
+  test('displays a recommendation when an option with recommendation is clicked', () => {
+    render(<InteractiveDecisionTree treeData={mockTreeData} />);
+    const noSunnyButton = screen.getByText("No, it is not sunny");
+    fireEvent.click(noSunnyButton);
+
+    expect(screen.getByText("Recommendation")).toBeInTheDocument();
+    expect(screen.getByText(mockTreeData.nodes.node1.options[1].recommendation)).toBeInTheDocument();
+    expect(screen.getByText("Path Taken:")).toBeInTheDocument();
+    expect(screen.getByText("Start Over")).toBeInTheDocument();
+  });
+
+  test('displays the path taken to reach a recommendation', () => {
+    render(<InteractiveDecisionTree treeData={mockTreeData} />);
+    fireEvent.click(screen.getByText("Yes, it is sunny"));
+    fireEvent.click(screen.getByText("No, it is cool")); // Leads to "Go for a hike."
+
+    expect(screen.getByText("Recommendation")).toBeInTheDocument();
+    expect(screen.getByText("Go for a hike.")).toBeInTheDocument();
+
+    const pathItems = screen.getAllByRole('listitem');
+    expect(pathItems).toHaveLength(2);
+    expect(pathItems[0]).toHaveTextContent(`Q: ${mockTreeData.nodes.node1.question}`);
+    expect(pathItems[0]).toHaveTextContent(`A: ${mockTreeData.nodes.node1.options[0].answer}`);
+    expect(pathItems[1]).toHaveTextContent(`Q: ${mockTreeData.nodes.node2.question}`);
+    expect(pathItems[1]).toHaveTextContent(`A: ${mockTreeData.nodes.node2.options[1].answer}`);
+  });
+
+  test('handles "Start Over" button correctly', () => {
+    render(<InteractiveDecisionTree treeData={mockTreeData} />);
+    fireEvent.click(screen.getByText("No, it is not sunny")); // Reach recommendation
+
+    expect(screen.getByText("Recommendation")).toBeInTheDocument();
+    const startOverButton = screen.getByText("Start Over");
+    fireEvent.click(startOverButton);
+
+    // Should be back to the initial state
+    expect(screen.getByText(mockTreeData.nodes.node1.question)).toBeInTheDocument();
+    expect(screen.queryByText("Recommendation")).not.toBeInTheDocument();
+  });
+
+  test('renders within a Card component', () => {
+    render(<InteractiveDecisionTree treeData={mockTreeData} />);
+    expect(screen.getByTestId('card')).toBeInTheDocument();
+  });
+});

--- a/system-design-study-app/src/components/common/MermaidDiagram.test.jsx
+++ b/system-design-study-app/src/components/common/MermaidDiagram.test.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MermaidDiagram from './MermaidDiagram';
+
+// Mock the Card component
+jest.mock('./Card', () => ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>);
+
+describe('MermaidDiagram', () => {
+  const mockDiagramDefinition = 'graph TD;\nA-->B;';
+  let mockMermaidAPI;
+
+  beforeEach(() => {
+    // Reset the global mermaid object and its initialized state for each test
+    mockMermaidAPI = {
+      initialize: jest.fn(),
+      render: jest.fn((id, definition, callback) => {
+        // Simulate successful rendering by calling the callback with mock SVG code
+        callback('<svg data-testid="mermaid-svg"></svg>');
+      }),
+      isInitialized: false, // Ensure this is reset
+    };
+    window.mermaid = mockMermaidAPI;
+  });
+
+  afterEach(() => {
+    // Clean up the global mermaid object
+    delete window.mermaid;
+    // Clean up any temporary divs that might be left in the body from tests
+    const tempElements = document.querySelectorAll('[id^="render-temp-mermaid-"]');
+    tempElements.forEach(el => el.remove());
+  });
+
+  test('renders Card component', () => {
+    render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test1" />);
+    expect(screen.getByTestId('card')).toBeInTheDocument();
+  });
+
+  test('initializes Mermaid if not already initialized', () => {
+    render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-init" />);
+    expect(mockMermaidAPI.initialize).toHaveBeenCalledWith({
+      startOnLoad: false,
+      theme: 'default',
+    });
+    expect(mockMermaidAPI.isInitialized).toBe(true);
+  });
+
+  test('does not re-initialize Mermaid if already initialized', () => {
+    window.mermaid.isInitialized = true; // Simulate already initialized
+    render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-no-reinit" />);
+    expect(mockMermaidAPI.initialize).not.toHaveBeenCalled();
+  });
+
+  test('calls mermaid.render with diagram definition and renders SVG', async () => {
+    await act(async () => {
+      render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-render" />);
+    });
+    // Check that render was called. The first argument is a generated ID.
+    expect(mockMermaidAPI.render).toHaveBeenCalledWith(
+      expect.stringContaining('render-temp-mermaid-test-render'), // Or a more generic matcher if ID is random
+      mockDiagramDefinition,
+      expect.any(Function)
+    );
+    expect(screen.getByTestId('mermaid-svg')).toBeInTheDocument();
+  });
+
+  test('clears previous diagram when definition changes', async () => {
+    const { rerender } = render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-change" />);
+    expect(screen.getByTestId('mermaid-svg')).toBeInTheDocument();
+
+    const newDefinition = 'graph LR;\nC-->D;';
+    mockMermaidAPI.render.mockImplementationOnce((id, definition, callback) => {
+      callback('<svg data-testid="mermaid-svg-new"></svg>');
+    });
+
+    await act(async () => {
+      rerender(<MermaidDiagram diagramDefinition={newDefinition} diagramId="test-change" />);
+    });
+
+    expect(screen.queryByTestId('mermaid-svg')).not.toBeInTheDocument();
+    expect(screen.getByTestId('mermaid-svg-new')).toBeInTheDocument();
+    expect(mockMermaidAPI.render).toHaveBeenCalledWith(
+      expect.stringContaining('render-temp-mermaid-test-change'),
+      newDefinition,
+      expect.any(Function)
+    );
+  });
+
+  test('displays error message if mermaid rendering fails', async () => {
+    mockMermaidAPI.render.mockImplementationOnce((id, definition, callback) => {
+      throw new Error('Test render error');
+    });
+    await act(async () => {
+      render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-error" />);
+    });
+    expect(screen.getByText(/Error rendering diagram: Test render error/)).toBeInTheDocument();
+  });
+
+  test('displays message if mermaid library is not available', () => {
+    delete window.mermaid; // Simulate mermaid not loaded
+    render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-no-mermaid" />);
+    expect(screen.getByText('Mermaid library not available yet. Waiting for CDN...')).toBeInTheDocument();
+  });
+
+  test('clears container if diagramDefinition is empty or null', async () => {
+    const { rerender } = render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-clear" />);
+    expect(screen.getByTestId('mermaid-svg')).toBeInTheDocument();
+
+    await act(async () => {
+      rerender(<MermaidDiagram diagramDefinition="" diagramId="test-clear" />);
+    });
+    expect(screen.queryByTestId('mermaid-svg')).not.toBeInTheDocument();
+
+    await act(async () => {
+      rerender(<MermaidDiagram diagramDefinition={null} diagramId="test-clear" />);
+    });
+    expect(screen.queryByTestId('mermaid-svg')).not.toBeInTheDocument();
+  });
+
+   test('handles cases where containerRef might become null during async rendering (though unlikely with normal flow)', async () => {
+    const { unmount } = render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-unmount" />);
+
+    mockMermaidAPI.render.mockImplementationOnce((id, definition, callback) => {
+      // Simulate unmount before callback
+      unmount();
+      // Callback is called after unmount, containerRef.current would be null
+      // We are testing that this doesn't throw an error inside the callback
+      expect(() => callback('<svg></svg>')).not.toThrow();
+    });
+
+    // Re-trigger useEffect by changing a prop; this is a bit artificial for this exact scenario
+    // but helps simulate the async nature if render was delayed.
+    // In a real scenario, the component unmounting during an async mermaid.render callback is the concern.
+    await act(async () => {
+       render(<MermaidDiagram diagramDefinition={mockDiagramDefinition + " "} diagramId="test-unmount" />);
+    });
+    // No explicit assertion needed other than not throwing, which is covered by the expect in mock.
+  });
+
+
+});

--- a/system-design-study-app/src/components/common/QuizView.jsx
+++ b/system-design-study-app/src/components/common/QuizView.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import Button from './Button'; // Import the common Button component
+import Card from './Card'; // Import the common Card component
 
 /**
  * Renders an interactive quiz component.

--- a/system-design-study-app/src/components/common/QuizView.test.jsx
+++ b/system-design-study-app/src/components/common/QuizView.test.jsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import QuizView from './QuizView';
+
+// Mock common components
+jest.mock('./Button', () => ({ children, onClick, disabled, className, ...rest }) => (
+  <button data-testid="button" onClick={onClick} disabled={disabled} className={className} {...rest}>
+    {children}
+  </button>
+));
+jest.mock('./Card', () => ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>);
+
+const mockQuizData = {
+  quizTitle: "Test Quiz",
+  questions: [
+    {
+      id: "q1",
+      text: "What is 2 + 2?",
+      options: [
+        { id: "q1opt1", text: "3" },
+        { id: "q1opt2", text: "4" },
+        { id: "q1opt3", text: "5" },
+      ],
+      correctOptionId: "q1opt2",
+      explanation: "2 + 2 equals 4.",
+    },
+    {
+      id: "q2",
+      text: "What is the capital of France?",
+      options: [
+        { id: "q2opt1", text: "Berlin" },
+        { id: "q2opt2", text: "Madrid" },
+        { id: "q2opt3", text: "Paris" },
+      ],
+      correctOptionId: "q2opt3",
+      explanation: "Paris is the capital of France.",
+    },
+  ],
+};
+
+const emptyQuizData = {
+  quizTitle: "Empty Quiz",
+  questions: [],
+};
+
+describe('QuizView', () => {
+  test('renders error message if no questions are provided', () => {
+    render(<QuizView quizTitle="No Questions Quiz" questions={[]} />);
+    expect(screen.getByText('No quiz questions available.')).toBeInTheDocument();
+  });
+
+  test('renders error message if questions prop is undefined', () => {
+    render(<QuizView quizTitle="Undefined Questions Quiz" questions={undefined} />);
+    expect(screen.getByText('No quiz questions available.')).toBeInTheDocument();
+  });
+
+  test('renders the first question and its options', () => {
+    render(<QuizView {...mockQuizData} />);
+    expect(screen.getByText(mockQuizData.quizTitle)).toBeInTheDocument();
+    expect(screen.getByText(`Question 1 of ${mockQuizData.questions.length}`)).toBeInTheDocument();
+    expect(screen.getByText(mockQuizData.questions[0].text)).toBeInTheDocument();
+    mockQuizData.questions[0].options.forEach(opt => {
+      expect(screen.getByText(opt.text)).toBeInTheDocument();
+    });
+    expect(screen.getByText('Submit Answer')).toBeDisabled(); // Initially disabled
+  });
+
+  test('enables Submit Answer button when an option is selected', () => {
+    render(<QuizView {...mockQuizData} />);
+    fireEvent.click(screen.getByText(mockQuizData.questions[0].options[0].text)); // Select first option
+    expect(screen.getByText('Submit Answer')).toBeEnabled();
+  });
+
+  test('shows explanation and correct/incorrect status after submitting an answer', () => {
+    render(<QuizView {...mockQuizData} />);
+    const question1 = mockQuizData.questions[0];
+
+    // Select correct answer
+    fireEvent.click(screen.getByText(question1.options[1].text)); // "4"
+    fireEvent.click(screen.getByText('Submit Answer'));
+
+    expect(screen.getByText('Explanation:')).toBeInTheDocument();
+    expect(screen.getByText(question1.explanation)).toBeInTheDocument();
+    // Correct option should be visibly correct (e.g., specific styling, not easily testable with RTL without more specific selectors/attributes)
+    // Incorrect options should be visibly distinct or disabled
+
+    // Check for "Next Question" button
+    expect(screen.getByText('Next Question')).toBeInTheDocument();
+  });
+
+  test('navigates to the next question', () => {
+    render(<QuizView {...mockQuizData} />);
+    fireEvent.click(screen.getByText(mockQuizData.questions[0].options[0].text));
+    fireEvent.click(screen.getByText('Submit Answer'));
+    fireEvent.click(screen.getByText('Next Question'));
+
+    expect(screen.getByText(`Question 2 of ${mockQuizData.questions.length}`)).toBeInTheDocument();
+    expect(screen.getByText(mockQuizData.questions[1].text)).toBeInTheDocument();
+  });
+
+  test('shows results after the last question', () => {
+    render(<QuizView {...mockQuizData} />);
+    // Answer first question
+    fireEvent.click(screen.getByText(mockQuizData.questions[0].options[1].text)); // Correct
+    fireEvent.click(screen.getByText('Submit Answer'));
+    fireEvent.click(screen.getByText('Next Question'));
+
+    // Answer second question
+    fireEvent.click(screen.getByText(mockQuizData.questions[1].options[2].text)); // Correct
+    fireEvent.click(screen.getByText('Submit Answer'));
+    fireEvent.click(screen.getByText('Show Results'));
+
+    expect(screen.getByText(`${mockQuizData.quizTitle} - Results`)).toBeInTheDocument();
+    expect(screen.getByText(`You got 2 out of ${mockQuizData.questions.length} correct!`)).toBeInTheDocument();
+    expect(screen.getByText('Retake Quiz')).toBeInTheDocument();
+  });
+
+  test('calculates score correctly', () => {
+    render(<QuizView {...mockQuizData} />);
+    // Q1: Correct
+    fireEvent.click(screen.getByText(mockQuizData.questions[0].options[1].text));
+    fireEvent.click(screen.getByText('Submit Answer'));
+    fireEvent.click(screen.getByText('Next Question'));
+
+    // Q2: Incorrect
+    fireEvent.click(screen.getByText(mockQuizData.questions[1].options[0].text));
+    fireEvent.click(screen.getByText('Submit Answer'));
+    fireEvent.click(screen.getByText('Show Results'));
+
+    expect(screen.getByText(`You got 1 out of ${mockQuizData.questions.length} correct!`)).toBeInTheDocument();
+  });
+
+
+  test('handles "Retake Quiz" button correctly', () => {
+    render(<QuizView {...mockQuizData} />);
+    // Go to results page
+    fireEvent.click(screen.getByText(mockQuizData.questions[0].options[0].text));
+    fireEvent.click(screen.getByText('Submit Answer'));
+    fireEvent.click(screen.getByText('Next Question'));
+    fireEvent.click(screen.getByText(mockQuizData.questions[1].options[0].text));
+    fireEvent.click(screen.getByText('Submit Answer'));
+    fireEvent.click(screen.getByText('Show Results'));
+
+    expect(screen.getByText(`${mockQuizData.quizTitle} - Results`)).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Retake Quiz'));
+
+    // Should be back to the first question
+    expect(screen.getByText(`Question 1 of ${mockQuizData.questions.length}`)).toBeInTheDocument();
+    expect(screen.getByText(mockQuizData.questions[0].text)).toBeInTheDocument();
+  });
+
+  test('renders within a Card component', () => {
+    render(<QuizView {...mockQuizData} />);
+    expect(screen.getAllByTestId('card').length).toBeGreaterThan(0); // QuizView uses Card for questions and results
+  });
+});

--- a/system-design-study-app/src/components/databases/SectionSqlDB.test.jsx
+++ b/system-design-study-app/src/components/databases/SectionSqlDB.test.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import SectionSqlDB from './SectionSqlDB';
+
+// Mock Material UI Icons
+jest.mock('@mui/icons-material/KeyboardArrowDown', () => () => <svg data-testid="KeyboardArrowDownIcon" />);
+jest.mock('@mui/icons-material/KeyboardArrowUp', () => () => <svg data-testid="KeyboardArrowUpIcon" />);
+
+// Mock common components if they have complex logic or external dependencies not relevant to this test
+jest.mock('../common/Card', () => ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>);
+jest.mock('../common/Button', () => ({ children, onClick, className, ...rest }) => (
+  <button data-testid="button" onClick={onClick} className={className} {...rest}>
+    {children}
+  </button>
+));
+
+describe('SectionSqlDB', () => {
+  const mockDeepDiveData = [
+    { title: "Normalization vs. Denormalization", content: "<p>Normalization content.</p>" },
+    { title: "Indexing Strategies (B-Trees, B+Trees)", content: "<p>Indexing content.</p>" },
+  ];
+
+  // A simplified version of the actual component's structure for testing,
+  // as the original deepDiveData is internal to SectionSqlDB.jsx
+  // We are more interested in the AccordionItem behavior here.
+
+  test('renders the main title and introductory paragraph', () => {
+    render(<SectionSqlDB />);
+    expect(screen.getByText('Relational Databases (SQL)')).toBeInTheDocument();
+    expect(screen.getByText(/The bedrock of many applications/)).toBeInTheDocument();
+  });
+
+  test('renders accordion items based on deepDiveData', () => {
+    render(<SectionSqlDB />);
+    // The actual titles are defined within the component, so we use them directly.
+    expect(screen.getByText('Normalization vs. Denormalization')).toBeInTheDocument();
+    expect(screen.getByText('Indexing Strategies (B-Trees, B+Trees)')).toBeInTheDocument();
+    expect(screen.getByText('ACID Properties & Transactions')).toBeInTheDocument();
+    expect(screen.getByText('SQL Joins (Inner, Outer, Self, Cross)')).toBeInTheDocument();
+    expect(screen.getByText('Query Optimization & Execution Plans')).toBeInTheDocument();
+  });
+
+  test('accordion items are initially closed and show KeyboardArrowDownIcon', () => {
+    render(<SectionSqlDB />);
+    const firstItemTitle = 'Normalization vs. Denormalization';
+    // Content should not be visible initially
+    expect(screen.queryByText('Normalization content.')).not.toBeVisible();
+
+    // Check for down arrow icon. The button contains the icon.
+    const button = screen.getByText(firstItemTitle).closest('button');
+    expect(button).not.toBeNull();
+    // Check within the button for the down arrow icon
+    expect(button.querySelector('[data-testid="KeyboardArrowDownIcon"]')).toBeInTheDocument();
+    expect(button.querySelector('[data-testid="KeyboardArrowUpIcon"]')).not.toBeInTheDocument();
+  });
+
+  test('clicking an accordion item opens it, shows content, and KeyboardArrowUpIcon', () => {
+    render(<SectionSqlDB />);
+    const firstItemTitle = 'Normalization vs. Denormalization';
+    const button = screen.getByText(firstItemTitle);
+
+    fireEvent.click(button);
+
+    // Content should now be visible. We use dangerouslySetInnerHTML so direct text match for <p> is tricky.
+    // A better approach would be to have a test-id on the content div if possible,
+    // or check for a snippet of the text without HTML.
+    expect(screen.getByText(/Normalization content\./)).toBeInTheDocument();
+    expect(screen.getByText(firstItemTitle).closest('button').querySelector('[data-testid="KeyboardArrowUpIcon"]')).toBeInTheDocument();
+    expect(screen.getByText(firstItemTitle).closest('button').querySelector('[data-testid="KeyboardArrowDownIcon"]')).not.toBeInTheDocument();
+  });
+
+  test('clicking an open accordion item closes it', () => {
+    render(<SectionSqlDB />);
+    const firstItemTitle = 'Normalization vs. Denormalization';
+    const button = screen.getByText(firstItemTitle);
+
+    // Open it first
+    fireEvent.click(button);
+    expect(screen.getByText(/Normalization content\./)).toBeInTheDocument();
+    expect(button.querySelector('[data-testid="KeyboardArrowUpIcon"]')).toBeInTheDocument();
+
+    // Click again to close
+    fireEvent.click(button);
+    // A robust way to check for not visible/not present if content is removed from DOM:
+    expect(screen.queryByText(/Normalization content\./)).not.toBeVisible();
+    expect(button.querySelector('[data-testid="KeyboardArrowDownIcon"]')).toBeInTheDocument();
+    expect(button.querySelector('[data-testid="KeyboardArrowUpIcon"]')).not.toBeInTheDocument();
+  });
+
+   test('only one accordion item can be open at a time', () => {
+    render(<SectionSqlDB />);
+    const firstItemTitle = "Normalization vs. Denormalization";
+    const secondItemTitle = "Indexing Strategies (B-Trees, B+Trees)";
+
+    const firstButton = screen.getByText(firstItemTitle);
+    const secondButton = screen.getByText(secondItemTitle);
+
+    // Open first item
+    fireEvent.click(firstButton);
+    expect(screen.getByText(/Normalization content\./)).toBeInTheDocument();
+    expect(screen.queryByText(/Indexing content\./)).not.toBeVisible();
+
+    // Open second item
+    fireEvent.click(secondButton);
+    expect(screen.queryByText(/Normalization content\./)).not.toBeVisible();
+    expect(screen.getByText(/Indexing content\./)).toBeInTheDocument();
+    expect(secondButton.querySelector('[data-testid="KeyboardArrowUpIcon"]')).toBeInTheDocument();
+    expect(firstButton.querySelector('[data-testid="KeyboardArrowDownIcon"]')).toBeInTheDocument();
+  });
+});

--- a/system-design-study-app/src/components/loadbalancing/ScenariosView.test.jsx
+++ b/system-design-study-app/src/components/loadbalancing/ScenariosView.test.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ScenariosView from './ScenariosView';
+
+describe('ScenariosView', () => {
+  const mockAppData = {
+    scenarios: [
+      {
+        id: 'scenario1',
+        title: 'High-Traffic E-commerce Site',
+        description: 'A rapidly growing e-commerce platform experiencing frequent traffic spikes.',
+        solution: {
+          strategy: 'Utilize a combination of L7 and L4 load balancers with auto-scaling.',
+          components: ['CDN', 'L7 Load Balancer (e.g., ALB/App Gateway)', 'L4 Load Balancer (e.g., NLB/Network LB)', 'Auto-scaling Groups for application servers'],
+        },
+      },
+      {
+        id: 'scenario2',
+        title: 'Global Application Delivery',
+        description: 'An application with users distributed worldwide, requiring low latency.',
+        solution: {
+          strategy: 'Employ Global Server Load Balancing (GSLB) and regional load balancers.',
+          components: ['DNS-based GSLB', 'Regional L7/L4 Load Balancers', 'Anycast IP Addressing'],
+        },
+      },
+    ],
+  };
+
+  const emptyAppData = {
+    scenarios: [],
+  };
+
+  const nullAppData = null;
+
+  test('renders loading message when appData is null', () => {
+    render(<ScenariosView appData={nullAppData} />);
+    expect(screen.getByText('Loading scenario data...')).toBeInTheDocument();
+  });
+
+  test('renders no data message when scenarios is empty', () => {
+    render(<ScenariosView appData={emptyAppData} />);
+    expect(screen.getByText('No load balancing scenario data available.')).toBeInTheDocument();
+  });
+
+  test('renders main title', () => {
+    render(<ScenariosView appData={mockAppData} />);
+    expect(screen.getByText('Load Balancing Scenarios')).toBeInTheDocument();
+  });
+
+  test('renders all scenarios from appData', () => {
+    render(<ScenariosView appData={mockAppData} />);
+    expect(screen.getByText('High-Traffic E-commerce Site')).toBeInTheDocument();
+    expect(screen.getByText('Global Application Delivery')).toBeInTheDocument();
+  });
+
+  test('renders description, strategy, and components for each scenario', () => {
+    render(<ScenariosView appData={mockAppData} />);
+    const scenario1Data = mockAppData.scenarios[0];
+    const scenario2Data = mockAppData.scenarios[1];
+
+    // Check Scenario 1 data
+    expect(screen.getByText(scenario1Data.description)).toBeInTheDocument();
+    expect(screen.getByText(scenario1Data.solution.strategy)).toBeInTheDocument();
+    scenario1Data.solution.components.forEach(component => expect(screen.getByText(component)).toBeInTheDocument());
+
+    // Check Scenario 2 data
+    expect(screen.getByText(scenario2Data.description)).toBeInTheDocument();
+    expect(screen.getByText(scenario2Data.solution.strategy)).toBeInTheDocument();
+    scenario2Data.solution.components.forEach(component => expect(screen.getByText(component)).toBeInTheDocument());
+  });
+
+  // Similar to TypesView, the nesting fix is indirectly verified by ensuring content renders correctly
+  // and by the absence of console hydration errors during testing.
+});

--- a/system-design-study-app/src/components/loadbalancing/TypesView.test.jsx
+++ b/system-design-study-app/src/components/loadbalancing/TypesView.test.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TypesView from './TypesView';
+
+// Mock child components if necessary, though for this view, direct rendering is okay
+// jest.mock('@mui/material', () => ({
+//   ...jest.requireActual('@mui/material'),
+//   List: ({ children, ...props }) => <ul {...props}>{children}</ul>,
+//   ListItem: ({ children, ...props }) => <li {...props}>{children}</li>,
+//   ListItemText: ({ primary, secondary, secondaryTypographyProps, ...props }) => (
+//     <div {...props}>
+//       <span>{primary}</span>
+//       {secondaryTypographyProps?.component === 'div' ? <div>{secondary}</div> : <p>{secondary}</p>}
+//     </div>
+//   ),
+//   Typography: ({ children, ...props }) => <div {...props}>{children}</div>,
+//   Paper: ({ children, ...props }) => <div {...props}>{children}</div>,
+//   Box: ({ children, ...props }) => <div {...props}>{children}</div>,
+//   Divider: (props) => <hr {...props} />,
+// }));
+
+
+describe('TypesView', () => {
+  const mockAppData = {
+    lbTypes: [
+      {
+        id: 'l4',
+        name: 'Layer 4 (Network) Load Balancer',
+        description: 'Distributes traffic based on network layer information (IP, port).',
+        pros: ['Fast', 'Simple'],
+        cons: ['Not content-aware'],
+        useCases: 'General purpose TCP/UDP load balancing.',
+      },
+      {
+        id: 'l7',
+        name: 'Layer 7 (Application) Load Balancer',
+        description: 'Distributes traffic based on application layer data (HTTP headers, cookies).',
+        pros: ['Content-aware routing', 'SSL termination'],
+        cons: ['Slower than L4', 'More complex'],
+        useCases: 'Web applications, microservices.',
+      },
+    ],
+  };
+
+  const emptyAppData = {
+    lbTypes: [],
+  };
+
+  const nullAppData = null;
+
+  test('renders loading message when appData is null', () => {
+    render(<TypesView appData={nullAppData} />);
+    expect(screen.getByText('Loading load balancer types data...')).toBeInTheDocument();
+  });
+
+  test('renders no data message when lbTypes is empty', () => {
+    render(<TypesView appData={emptyAppData} />);
+    expect(screen.getByText('No load balancer type data available.')).toBeInTheDocument();
+  });
+
+  test('renders main title', () => {
+    render(<TypesView appData={mockAppData} />);
+    expect(screen.getByText('Types of Load Balancers')).toBeInTheDocument();
+  });
+
+  test('renders all load balancer types from appData', () => {
+    render(<TypesView appData={mockAppData} />);
+    expect(screen.getByText('Layer 4 (Network) Load Balancer')).toBeInTheDocument();
+    expect(screen.getByText('Layer 7 (Application) Load Balancer')).toBeInTheDocument();
+  });
+
+  test('renders description, pros, cons, and use cases for each type', () => {
+    render(<TypesView appData={mockAppData} />);
+    const l4Data = mockAppData.lbTypes[0];
+    const l7Data = mockAppData.lbTypes[1];
+
+    // Check L4 data
+    expect(screen.getByText(l4Data.description)).toBeInTheDocument();
+    l4Data.pros.forEach(pro => expect(screen.getByText(pro)).toBeInTheDocument());
+    l4Data.cons.forEach(con => expect(screen.getByText(con)).toBeInTheDocument());
+    expect(screen.getByText(l4Data.useCases)).toBeInTheDocument();
+
+    // Check L7 data
+    expect(screen.getByText(l7Data.description)).toBeInTheDocument();
+    l7Data.pros.forEach(pro => expect(screen.getByText(pro)).toBeInTheDocument());
+    l7Data.cons.forEach(con => expect(screen.getByText(con)).toBeInTheDocument());
+    expect(screen.getByText(l7Data.useCases)).toBeInTheDocument();
+  });
+
+  // The fix for nesting errors was to use secondaryTypographyProps={{ component: 'div' }}
+  // While RTL doesn't easily allow checking the exact rendered tag without complex queries or snapshots,
+  // these tests ensure that the content (including lists for pros/cons) is rendered.
+  // The absence of console warnings during test runs (if configured to fail on them)
+  // would be an indirect confirmation of the fix's success in a testing environment.
+  // For direct DOM structure validation, snapshot testing or more specific queries might be used,
+  // but that can make tests more brittle.
+});


### PR DESCRIPTION
- Corrected HTML nesting issues in ProtocolsView.jsx using secondaryTypographyProps.
- Fixed ReferenceError for Card component in QuizView.jsx by adding the import.
- Refactored MermaidDiagram.jsx to improve initialization and rendering logic, aiming to resolve 'createElementNS' errors.
- Added Jest/RTL test suites for:
    - SectionSqlDB.jsx
    - TypesView.jsx
    - ScenariosView.jsx
    - ProtocolsView.jsx
    - InteractiveDecisionTree.jsx
    - QuizView.jsx
    - MermaidDiagram.jsx

These tests cover rendering, interactions, error states, and the specific fixes implemented in previous commits on this branch.