### PR TITLE
Fix: Test errors, nesting, card refs, and Mermaid issues

### DIFF
--- a/system-design-study-app/src/components/common/InteractiveDecisionTree.test.jsx
+++ b/system-design-study-app/src/components/common/InteractiveDecisionTree.test.jsx
@@ -5,12 +5,16 @@ import InteractiveDecisionTree from './InteractiveDecisionTree';
 import { vi } from 'vitest';
 
 // Mock common components
-vi.mock('./Button', () => ({ children, onClick, disabled, className, ...rest }) => (
-  <button data-testid="button" onClick={onClick} disabled={disabled} className={className} {...rest}>
-    {children}
-  </button>
-));
-vi.mock('./Card', () => ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>);
+vi.mock('./Button', () => ({
+  default: ({ children, onClick, disabled, className, ...rest }) => (
+    <button data-testid="button" onClick={onClick} disabled={disabled} className={className} {...rest}>
+      {children}
+    </button>
+  )
+}));
+vi.mock('./Card', () => ({
+  default: ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>
+}));
 
 
 const mockTreeData = {

--- a/system-design-study-app/src/components/common/MermaidDiagram.jsx
+++ b/system-design-study-app/src/components/common/MermaidDiagram.jsx
@@ -27,8 +27,6 @@ const MermaidDiagram = ({ diagramDefinition, diagramId }) => {
   useEffect(() => {
     const mermaidInstance = window.mermaid;
 
-    const mermaidInstance = window.mermaid;
-
     const initializeAndRender = async () => {
       if (!mermaidInstance) {
         if (containerRef.current) {

--- a/system-design-study-app/src/components/common/MermaidDiagram.test.jsx
+++ b/system-design-study-app/src/components/common/MermaidDiagram.test.jsx
@@ -5,7 +5,9 @@ import MermaidDiagram from './MermaidDiagram';
 import { vi } from 'vitest';
 
 // Mock the Card component
-vi.mock('./Card', () => ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>);
+vi.mock('./Card', () => ({
+  default: ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>
+}));
 
 describe('MermaidDiagram', () => {
   const mockDiagramDefinition = 'graph TD;\nA-->B;';

--- a/system-design-study-app/src/components/common/QuizView.test.jsx
+++ b/system-design-study-app/src/components/common/QuizView.test.jsx
@@ -5,12 +5,16 @@ import QuizView from './QuizView';
 import { vi } from 'vitest';
 
 // Mock common components
-vi.mock('./Button', () => ({ children, onClick, disabled, className, ...rest }) => (
-  <button data-testid="button" onClick={onClick} disabled={disabled} className={className} {...rest}>
-    {children}
-  </button>
-));
-vi.mock('./Card', () => ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>);
+vi.mock('./Button', () => ({
+  default: ({ children, onClick, disabled, className, ...rest }) => (
+    <button data-testid="button" onClick={onClick} disabled={disabled} className={className} {...rest}>
+      {children}
+    </button>
+  )
+}));
+vi.mock('./Card', () => ({
+  default: ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>
+}));
 
 const mockQuizData = {
   quizTitle: "Test Quiz",

--- a/system-design-study-app/src/components/databases/SectionSqlDB.test.jsx
+++ b/system-design-study-app/src/components/databases/SectionSqlDB.test.jsx
@@ -5,16 +5,21 @@ import SectionSqlDB from './SectionSqlDB';
 import { vi } from 'vitest';
 
 // Mock Material UI Icons
-vi.mock('@mui/icons-material/KeyboardArrowDown', () => () => <svg data-testid="KeyboardArrowDownIcon" />);
-vi.mock('@mui/icons-material/KeyboardArrowUp', () => () => <svg data-testid="KeyboardArrowUpIcon" />);
+// Assuming KeyboardArrowDown and KeyboardArrowUp are default exports from their modules
+vi.mock('@mui/icons-material/KeyboardArrowDown', () => ({ default: () => <svg data-testid="KeyboardArrowDownIcon" /> }));
+vi.mock('@mui/icons-material/KeyboardArrowUp', () => ({ default: () => <svg data-testid="KeyboardArrowUpIcon" /> }));
 
 // Mock common components if they have complex logic or external dependencies not relevant to this test
-vi.mock('../common/Card', () => ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>);
-vi.mock('../common/Button', () => ({ children, onClick, className, ...rest }) => (
-  <button data-testid="button" onClick={onClick} className={className} {...rest}>
-    {children}
-  </button>
-));
+vi.mock('../common/Card', () => ({
+  default: ({ children, ...rest }) => <div data-testid="card" {...rest}>{children}</div>
+}));
+vi.mock('../common/Button', () => ({
+  default: ({ children, onClick, className, ...rest }) => (
+    <button data-testid="button" onClick={onClick} className={className} {...rest}>
+      {children}
+    </button>
+  )
+}));
 
 describe('SectionSqlDB', () => {
   const mockDeepDiveData = [


### PR DESCRIPTION
- Corrected vi.mock usage in test files to return { default: ... } for default exports, resolving Vitest TypeErrors.
- Removed duplicate variable declaration in MermaidDiagram.jsx.
- Addressed HTML nesting errors in ProtocolsView.jsx and PatternsView.jsx by applying secondaryTypographyProps={{ component: 'div' }}.
- Fixed ReferenceError for Card component in ComparisonView.jsx.
- Refined MermaidDiagram.jsx initialization and rendering logic.