### PR TITLE
Fix: Test failures, Mermaid logic, and nesting error verifications

### DIFF
--- a/system-design-study-app/src/components/common/MermaidDiagram.jsx
+++ b/system-design-study-app/src/components/common/MermaidDiagram.jsx
@@ -26,6 +26,12 @@ const MermaidDiagram = ({ diagramDefinition, diagramId }) => {
 
   useEffect(() => {
     const initializeAndRender = async () => {
+      // Prioritize clearing if diagramDefinition is empty
+      if (containerRef.current && !diagramDefinition) {
+        containerRef.current.innerHTML = '';
+        return;
+      }
+
       const mermaidInstance = window.mermaid; // Define mermaidInstance inside the async function or pass as arg
       if (!mermaidInstance) {
         if (containerRef.current) {

--- a/system-design-study-app/src/components/common/MermaidDiagram.test.jsx
+++ b/system-design-study-app/src/components/common/MermaidDiagram.test.jsx
@@ -122,27 +122,39 @@ describe('MermaidDiagram', () => {
 
   test('clears container if diagramDefinition is empty or null', async () => {
     const { rerender } = render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-clear" />);
-    await screen.findByTestId('mermaid-svg');
+    await screen.findByTestId('mermaid-svg'); // Wait for initial render
 
+    // Test with empty string
     await act(async () => {
       rerender(<MermaidDiagram diagramDefinition="" diagramId="test-clear" />);
     });
-    expect(screen.getByText('Mermaid library not available yet. Retrying...')).toBeInTheDocument();
-  });
-
-  test('clears container if diagramDefinition is empty or null', async () => {
-    const { rerender } = render(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-clear" />);
-    await screen.findByTestId('mermaid-svg');
-
-    await act(async () => { // act might not be strictly needed
-      rerender(<MermaidDiagram diagramDefinition="" diagramId="test-clear" />);
-    });
     expect(screen.queryByTestId('mermaid-svg')).not.toBeInTheDocument();
+    // Ensure no error/retry message is shown, container should be empty
+    expect(screen.queryByText('Mermaid library not available yet. Retrying...')).toBeNull();
+    // Check that the container div itself is empty by querying its content.
+    // We expect the card to be there, but its inner div (the mermaid container) to be empty.
+    const cardElement = screen.getByTestId('card');
+    const mermaidContainer = cardElement.querySelector('div[key^="mermaid-"]'); // The direct child div
+    expect(mermaidContainer).toBeInTheDocument();
+    expect(mermaidContainer.innerHTML).toBe('');
+
+
+    // Test with null
+    // Re-render with the original definition first to ensure mermaid-svg is back
+    await act(async () => {
+      rerender(<MermaidDiagram diagramDefinition={mockDiagramDefinition} diagramId="test-clear" />);
+    });
+    await screen.findByTestId('mermaid-svg'); // Make sure it rendered again
 
     await act(async () => {
       rerender(<MermaidDiagram diagramDefinition={null} diagramId="test-clear" />);
     });
     expect(screen.queryByTestId('mermaid-svg')).not.toBeInTheDocument();
+    expect(screen.queryByText('Mermaid library not available yet. Retrying...')).toBeNull();
+    const cardElementAfterNull = screen.getByTestId('card');
+    const mermaidContainerAfterNull = cardElementAfterNull.querySelector('div[key^="mermaid-"]');
+    expect(mermaidContainerAfterNull).toBeInTheDocument();
+    expect(mermaidContainerAfterNull.innerHTML).toBe('');
   });
 
    test('handles cases where containerRef might become null during async rendering (though unlikely with normal flow)', async () => {

--- a/system-design-study-app/src/components/databases/SectionSqlDB.test.jsx
+++ b/system-design-study-app/src/components/databases/SectionSqlDB.test.jsx
@@ -71,7 +71,7 @@ describe('SectionSqlDB', () => {
     // Content should now be visible.
     const contentDiv = screen.getByTestId('accordion-content-0');
     expect(contentDiv).toBeInTheDocument();
-    expect(contentDiv).toHaveTextContent(/Normalization content/i); // Check for partial text within the div
+    expect(contentDiv).toHaveTextContent(/Normalization: Process of organizing data/i);
     expect(screen.getByText(firstItemTitle).closest('button').querySelector('[data-testid="KeyboardArrowUpIcon"]')).toBeInTheDocument();
     expect(screen.getByText(firstItemTitle).closest('button').querySelector('[data-testid="KeyboardArrowDownIcon"]')).not.toBeInTheDocument();
   });
@@ -83,8 +83,9 @@ describe('SectionSqlDB', () => {
 
     // Open it first
     fireEvent.click(button);
-    expect(screen.getByTestId('accordion-content-0')).toBeInTheDocument();
-    expect(screen.getByTestId('accordion-content-0')).toHaveTextContent(/Normalization content/i);
+    const openedContentDiv = screen.getByTestId('accordion-content-0');
+    expect(openedContentDiv).toBeInTheDocument();
+    expect(openedContentDiv).toHaveTextContent(/Normalization: Process of organizing data/i);
     expect(button.querySelector('[data-testid="KeyboardArrowUpIcon"]')).toBeInTheDocument();
 
     // Click again to close
@@ -104,15 +105,17 @@ describe('SectionSqlDB', () => {
 
     // Open first item
     fireEvent.click(firstButton);
-    expect(screen.getByTestId('accordion-content-0')).toBeInTheDocument();
-    expect(screen.getByTestId('accordion-content-0')).toHaveTextContent(/Normalization content/i);
+    const firstContentDiv = screen.getByTestId('accordion-content-0');
+    expect(firstContentDiv).toBeInTheDocument();
+    expect(firstContentDiv).toHaveTextContent(/Normalization: Process of organizing data/i);
     expect(screen.queryByTestId('accordion-content-1')).toBeNull();
 
     // Open second item
     fireEvent.click(secondButton);
     expect(screen.queryByTestId('accordion-content-0')).toBeNull();
-    expect(screen.getByTestId('accordion-content-1')).toBeInTheDocument();
-    expect(screen.getByTestId('accordion-content-1')).toHaveTextContent(/Indexing content/i);
+    const secondContentDiv = screen.getByTestId('accordion-content-1');
+    expect(secondContentDiv).toBeInTheDocument();
+    expect(secondContentDiv).toHaveTextContent(/Indexing Strategies.*B-Trees/i); // Using content from the actual data
     expect(secondButton.querySelector('[data-testid="KeyboardArrowUpIcon"]')).toBeInTheDocument();
     expect(firstButton.querySelector('[data-testid="KeyboardArrowDownIcon"]')).toBeInTheDocument();
   });


### PR DESCRIPTION
- Corrected MermaidDiagram.test.jsx mock for `render` to align with callback usage and updated assertions.
- Fixed assertions in SectionSqlDB.test.jsx to use data-testid and correctly check content rendered with dangerouslySetInnerHTML.
- Updated MermaidDiagram.jsx to prioritize clearing the container if diagramDefinition is empty.
- Re-verified HTML nesting fixes in ProtocolsView.jsx, PatternsView.jsx, and ScenariosView.jsx, and their data sources; these appear correct.
- Verified Card import in ComparisonView.jsx.

Note: Persistent Mermaid runtime 'createElementNS' errors in the browser may require further investigation beyond current component logic changes (e.g., related to CDN loading or environment specifics).