### PR TITLE
feat: Add tests for layout, sidebar, and content pages

### DIFF
--- a/system-design-study-app/src/components/apidesign/ApiDesignPage.test.jsx
+++ b/system-design-study-app/src/components/apidesign/ApiDesignPage.test.jsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ApiDesignPage from './ApiDesignPage';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mock child components
+jest.mock('../common/TopicPageLayout', () => ({ children, sidebar, content, topicTitle }) => (
+  <div data-testid="topic-page-layout">
+    <h1>{topicTitle}</h1>
+    <div data-testid="sidebar-prop-content">{sidebar}</div>
+    <div data-testid="content-prop-content">{content}</div>
+    {children}
+  </div>
+));
+
+jest.mock('../common/TopicSidebar', () => ({ topicTitle, sections, currentView, setCurrentView }) => (
+  <div data-testid="topic-sidebar">
+    <h2>{topicTitle}</h2>
+    <ul>
+      {sections.map(section => (
+        <li key={section.id} onClick={() => setCurrentView(section.id)}>
+          {section.title}
+        </li>
+      ))}
+    </ul>
+    <p>Current View in Mock: {currentView}</p>
+  </div>
+));
+
+// Mock view components
+jest.mock('./IntroApiDesign', () => () => <div data-testid="intro-api">IntroApiDesign Content</div>);
+jest.mock('./RestApiModule', () => () => <div data-testid="rest-api">RestApiModule Content</div>);
+jest.mock('./GraphQlModule', () => () => <div data-testid="graphql-api">GraphQlModule Content</div>);
+jest.mock('./GrpcApiModule', () => () => <div data-testid="grpc-api">GrpcApiModule Content</div>);
+jest.mock('./WebSocketsModule', () => () => <div data-testid="websockets-api">WebSocketsModule Content</div>);
+jest.mock('./WebhooksModule', () => () => <div data-testid="webhooks-api">WebhooksModule Content</div>);
+jest.mock('./SecurityApiModule', () => () => <div data-testid="security-api">SecurityApiModule Content</div>);
+jest.mock('./VersioningApiModule', () => () => <div data-testid="versioning-api">VersioningApiModule Content</div>);
+jest.mock('./BestPracticesApiModule', () => () => <div data-testid="best-practices-api">BestPracticesApiModule Content</div>);
+jest.mock('./ScenarioApiModule', () => () => <div data-testid="scenario-api">ScenarioApiModule Content</div>);
+
+const renderWithRouter = (ui) => {
+  return render(ui, { wrapper: BrowserRouter });
+};
+
+describe('ApiDesignPage', () => {
+  beforeEach(() => {
+    const mockIntersectionObserver = jest.fn();
+    mockIntersectionObserver.mockReturnValue({
+      observe: () => null,
+      unobserve: () => null,
+      disconnect: () => null
+    });
+    window.IntersectionObserver = mockIntersectionObserver;
+  });
+
+  it('renders TopicPageLayout with correct title', () => {
+    renderWithRouter(<ApiDesignPage />);
+    expect(screen.getByTestId('topic-page-layout')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'API Design' })).toBeInTheDocument();
+  });
+
+  it('renders TopicSidebar with correct title and sections', () => {
+    renderWithRouter(<ApiDesignPage />);
+    expect(screen.getByTestId('topic-sidebar')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'API Design', level: 2 })).toBeInTheDocument(); // From mock
+
+    expect(screen.getByText('Introduction')).toBeInTheDocument();
+    expect(screen.getByText('RESTful APIs')).toBeInTheDocument();
+    expect(screen.getByText('Interactive Scenario')).toBeInTheDocument();
+  });
+
+  it('renders the IntroApiDesign by default', () => {
+    renderWithRouter(<ApiDesignPage />);
+    expect(screen.getByTestId('intro-api')).toBeInTheDocument();
+  });
+
+  it('switches view when a section in TopicSidebar is clicked', () => {
+    renderWithRouter(<ApiDesignPage />);
+    expect(screen.getByTestId('intro-api')).toBeInTheDocument();
+    expect(screen.queryByTestId('rest-api')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('RESTful APIs'));
+
+    expect(screen.queryByTestId('intro-api')).not.toBeInTheDocument();
+    expect(screen.getByTestId('rest-api')).toBeInTheDocument();
+    expect(screen.getByText('Current View in Mock: rest')).toBeInTheDocument();
+  });
+
+  it('passes the Sidebar and Content to TopicPageLayout', () => {
+    renderWithRouter(<ApiDesignPage />);
+    const sidebarPropContent = screen.getByTestId('sidebar-prop-content');
+    expect(sidebarPropContent.contains(screen.getByTestId('topic-sidebar'))).toBe(true);
+
+    const contentPropContent = screen.getByTestId('content-prop-content');
+    expect(contentPropContent.contains(screen.getByTestId('intro-api'))).toBe(true);
+  });
+});

--- a/system-design-study-app/src/components/common/TopicPageLayout.test.jsx
+++ b/system-design-study-app/src/components/common/TopicPageLayout.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TopicPageLayout from './TopicPageLayout';
+
+// Mock the useColorMode hook
+jest.mock('@docusaurus/theme-common/internal', () => ({
+  useColorMode: () => ({
+    colorMode: 'light', // or 'dark'
+    setColorMode: jest.fn(),
+  }),
+}));
+
+// Mock ThemeSwitcher component
+jest.mock('../shared/ThemeSwitcher', () => () => <div data-testid="theme-switcher-mock">ThemeSwitcher</div>);
+
+
+describe('TopicPageLayout', () => {
+  it('renders sidebar and content props', () => {
+    const SidebarComponent = () => <div data-testid="sidebar">Sidebar Content</div>;
+    const ContentComponent = () => <div data-testid="content">Main Content</div>;
+
+    render(
+      <TopicPageLayout
+        sidebar={<SidebarComponent />}
+        content={<ContentComponent />}
+        topicTitle="Test Topic"
+      />
+    );
+
+    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Sidebar Content')).toBeInTheDocument();
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+    expect(screen.getByText('Main Content')).toBeInTheDocument();
+  });
+
+  it('renders the topic title', () => {
+    const SidebarComponent = () => <div>Sidebar</div>;
+    const ContentComponent = () => <div>Content</div>;
+
+    render(
+      <TopicPageLayout
+        sidebar={<SidebarComponent />}
+        content={<ContentComponent />}
+        topicTitle="My Awesome Topic"
+      />
+    );
+
+    expect(screen.getByText('My Awesome Topic')).toBeInTheDocument();
+  });
+
+  it('renders ThemeSwitcher', () => {
+    const SidebarComponent = () => <div>Sidebar</div>;
+    const ContentComponent = () => <div>Content</div>;
+
+    render(
+      <TopicPageLayout
+        sidebar={<SidebarComponent />}
+        content={<ContentComponent />}
+        topicTitle="Test Topic"
+      />
+    );
+    expect(screen.getByTestId('theme-switcher-mock')).toBeInTheDocument();
+  });
+});

--- a/system-design-study-app/src/components/common/TopicSidebar.test.jsx
+++ b/system-design-study-app/src/components/common/TopicSidebar.test.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TopicSidebar from './TopicSidebar';
+import { BrowserRouter } from 'react-router-dom'; // Import BrowserRouter
+
+// Mock the useColorMode hook used by ThemeSwitcher potentially if it's a deep child or for consistency
+jest.mock('@docusaurus/theme-common/internal', () => ({
+  useColorMode: () => ({
+    colorMode: 'light',
+    setColorMode: jest.fn(),
+  }),
+}));
+
+// Mock ThemeSwitcher component if it's directly or indirectly rendered by TopicSidebar
+// If TopicSidebar doesn't render ThemeSwitcher, this mock isn't strictly necessary here.
+jest.mock('../shared/ThemeSwitcher', () => () => <div data-testid="theme-switcher-mock">ThemeSwitcher</div>);
+
+
+describe('TopicSidebar', () => {
+  const mockSections = [
+    { id: 'intro', title: 'Introduction' },
+    { id: 'details', title: 'Details' },
+    { id: 'conclusion', title: 'Conclusion' },
+  ];
+  const mockSetCurrentView = jest.fn();
+  const topicTitle = "Test Topic";
+
+  const renderWithRouter = (ui, { route = '/' } = {}) => {
+    window.history.pushState({}, 'Test page', route);
+    return render(ui, { wrapper: BrowserRouter });
+  };
+
+  beforeEach(() => {
+    mockSetCurrentView.mockClear();
+  });
+
+  it('renders the topic title', () => {
+    renderWithRouter(
+      <TopicSidebar
+        topicTitle={topicTitle}
+        sections={mockSections}
+        currentView="intro"
+        setCurrentView={mockSetCurrentView}
+      />
+    );
+    expect(screen.getByText(topicTitle)).toBeInTheDocument();
+  });
+
+  it('renders all section links', () => {
+    renderWithRouter(
+      <TopicSidebar
+        topicTitle={topicTitle}
+        sections={mockSections}
+        currentView="intro"
+        setCurrentView={mockSetCurrentView}
+      />
+    );
+    mockSections.forEach(section => {
+      expect(screen.getByText(section.title)).toBeInTheDocument();
+    });
+  });
+
+  it('calls setCurrentView with the section id when a section link is clicked', () => {
+    renderWithRouter(
+      <TopicSidebar
+        topicTitle={topicTitle}
+        sections={mockSections}
+        currentView="intro"
+        setCurrentView={mockSetCurrentView}
+      />
+    );
+    const detailsLink = screen.getByText('Details');
+    fireEvent.click(detailsLink);
+    expect(mockSetCurrentView).toHaveBeenCalledWith('details');
+  });
+
+  it('applies active styles to the currentView link', () => {
+    const currentViewId = 'details';
+    renderWithRouter(
+      <TopicSidebar
+        topicTitle={topicTitle}
+        sections={mockSections}
+        currentView={currentViewId}
+        setCurrentView={mockSetCurrentView}
+      />
+    );
+    const activeLink = screen.getByText('Details');
+    // Check for a class that indicates active state.
+    // This depends on how active state is implemented in TopicSidebar.
+    // Assuming it adds a class like 'text-primary' or similar for active links.
+    // Or check for 'font-semibold' as per the component's code.
+    expect(activeLink).toHaveClass('font-semibold'); // Based on TopicSidebar current implementation
+    expect(activeLink).toHaveClass('text-primary'); // Based on TopicSidebar current implementation
+
+    const inactiveLink = screen.getByText('Introduction');
+    expect(inactiveLink).not.toHaveClass('font-semibold');
+    expect(inactiveLink).not.toHaveClass('text-primary');
+  });
+
+  it('renders "Back to Home" link and it points to "/"', () => {
+    renderWithRouter(
+      <TopicSidebar
+        topicTitle={topicTitle}
+        sections={mockSections}
+        currentView="intro"
+        setCurrentView={mockSetCurrentView}
+      />
+    );
+    const backToHomeLink = screen.getByText('Back to Home');
+    expect(backToHomeLink).toBeInTheDocument();
+    // Check if the link points to "/"
+    expect(backToHomeLink.closest('a')).toHaveAttribute('href', '/');
+  });
+
+});

--- a/system-design-study-app/src/pages/CachesPage.test.jsx
+++ b/system-design-study-app/src/pages/CachesPage.test.jsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CachesPage from './CachesPage';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mock child components
+jest.mock('../components/common/TopicPageLayout', () => ({ children, sidebar, content, topicTitle }) => (
+  <div data-testid="topic-page-layout">
+    <h1>{topicTitle}</h1>
+    <div data-testid="sidebar-prop-content">{sidebar}</div>
+    <div data-testid="content-prop-content">{content}</div>
+    {children}
+  </div>
+));
+
+jest.mock('../components/common/TopicSidebar', () => ({ topicTitle, sections, currentView, setCurrentView }) => (
+  <div data-testid="topic-sidebar">
+    <h2>{topicTitle}</h2>
+    <ul>
+      {sections.map(section => (
+        <li key={section.id} onClick={() => setCurrentView(section.id)}>
+          {section.title}
+        </li>
+      ))}
+    </ul>
+    <p>Current View in Mock: {currentView}</p>
+  </div>
+));
+
+// Mock view components
+jest.mock('../components/caches/FundamentalsView', () => () => <div data-testid="fundamentals-view">FundamentalsView Content</div>);
+jest.mock('../components/caches/PatternsView', () => () => <div data-testid="patterns-view">PatternsView Content</div>);
+jest.mock('../components/caches/StrategiesView', () => () => <div data-testid="strategies-view">StrategiesView Content</div>);
+jest.mock('../components/caches/CachepediaView', () => () => <div data-testid="cachepedia-view">CachepediaView Content</div>);
+jest.mock('../components/caches/ScenariosView', () => () => <div data-testid="scenarios-view">ScenariosView Content</div>);
+jest.mock('../components/caches/PracticeView', () => () => <div data-testid="practice-view">PracticeView Content</div>);
+jest.mock('../components/caches/CodeLibraryView', () => () => <div data-testid="code-library-view">CodeLibraryView Content</div>);
+
+const renderWithRouter = (ui) => {
+  return render(ui, { wrapper: BrowserRouter });
+};
+
+describe('CachesPage', () => {
+  beforeEach(() => {
+    const mockIntersectionObserver = jest.fn();
+    mockIntersectionObserver.mockReturnValue({
+      observe: () => null,
+      unobserve: () => null,
+      disconnect: () => null
+    });
+    window.IntersectionObserver = mockIntersectionObserver;
+  });
+
+  it('renders TopicPageLayout with correct title', () => {
+    renderWithRouter(<CachesPage />);
+    expect(screen.getByTestId('topic-page-layout')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Caching Strategies' })).toBeInTheDocument();
+  });
+
+  it('renders TopicSidebar with correct title and sections', () => {
+    renderWithRouter(<CachesPage />);
+    expect(screen.getByTestId('topic-sidebar')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Caching Strategies', level: 2 })).toBeInTheDocument(); // From mock
+
+    expect(screen.getByText('Fundamentals')).toBeInTheDocument();
+    expect(screen.getByText('Caching Patterns')).toBeInTheDocument();
+    expect(screen.getByText('Code Library')).toBeInTheDocument();
+  });
+
+  it('renders the FundamentalsView by default', () => {
+    renderWithRouter(<CachesPage />);
+    expect(screen.getByTestId('fundamentals-view')).toBeInTheDocument();
+  });
+
+  it('switches view when a section in TopicSidebar is clicked', () => {
+    renderWithRouter(<CachesPage />);
+    expect(screen.getByTestId('fundamentals-view')).toBeInTheDocument();
+    expect(screen.queryByTestId('patterns-view')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Caching Patterns'));
+
+    expect(screen.queryByTestId('fundamentals-view')).not.toBeInTheDocument();
+    expect(screen.getByTestId('patterns-view')).toBeInTheDocument();
+    expect(screen.getByText('Current View in Mock: patterns')).toBeInTheDocument();
+  });
+
+  it('passes the Sidebar and Content to TopicPageLayout', () => {
+    renderWithRouter(<CachesPage />);
+    const sidebarPropContent = screen.getByTestId('sidebar-prop-content');
+    expect(sidebarPropContent.contains(screen.getByTestId('topic-sidebar'))).toBe(true);
+
+    const contentPropContent = screen.getByTestId('content-prop-content');
+    expect(contentPropContent.contains(screen.getByTestId('fundamentals-view'))).toBe(true);
+  });
+});

--- a/system-design-study-app/src/pages/DatabasesPage.test.jsx
+++ b/system-design-study-app/src/pages/DatabasesPage.test.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import DatabasesPage from './DatabasesPage';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mock child components
+jest.mock('../components/common/TopicPageLayout', () => ({ children, sidebar, content, topicTitle }) => (
+  <div data-testid="topic-page-layout">
+    <h1>{topicTitle}</h1>
+    <div data-testid="sidebar-prop-content">{sidebar}</div>
+    <div data-testid="content-prop-content">{content}</div>
+    {children}
+  </div>
+));
+
+jest.mock('../components/common/TopicSidebar', () => ({ topicTitle, sections, currentView, setCurrentView }) => (
+  <div data-testid="topic-sidebar">
+    <h2>{topicTitle}</h2>
+    <ul>
+      {sections.map(section => (
+        <li key={section.id} onClick={() => setCurrentView(section.id)}>
+          {section.title}
+        </li>
+      ))}
+    </ul>
+    <p>Current View in Mock: {currentView}</p>
+  </div>
+));
+
+// Mock view components
+jest.mock('../components/databases/SectionIntroDB', () => () => <div data-testid="intro-db">IntroDB Content</div>);
+jest.mock('../components/databases/SectionSqlDB', () => () => <div data-testid="sql-db">SqlDB Content</div>);
+jest.mock('../components/databases/SectionNoSqlDB', () => () => <div data-testid="nosql-db">NoSqlDB Content</div>);
+jest.mock('../components/databases/SectionTransactionsDB', () => () => <div data-testid="transactions-db">TransactionsDB Content</div>);
+jest.mock('../components/databases/SectionReplicationDB', () => () => <div data-testid="replication-db">ReplicationDB Content</div>);
+jest.mock('../components/databases/SectionShardingDB', () => () => <div data-testid="sharding-db">ShardingDB Content</div>);
+jest.mock('../components/databases/SectionCapTheoremDB', () => () => <div data-testid="cap-theorem-db">CapTheoremDB Content</div>);
+jest.mock('../components/databases/SectionIndexesDB', () => () => <div data-testid="indexes-db">IndexesDB Content</div>);
+jest.mock('../components/databases/SectionDataModelsDB', () => () => <div data-testid="data-models-db">DataModelsDB Content</div>);
+jest.mock('../components/databases/SectionUseCasesDB', () => () => <div data-testid="use-cases-db">UseCasesDB Content</div>);
+jest.mock('../components/databases/SectionGlossaryDB', () => () => <div data-testid="glossary-db">GlossaryDB Content</div>);
+
+const renderWithRouter = (ui) => {
+  return render(ui, { wrapper: BrowserRouter });
+};
+
+describe('DatabasesPage', () => {
+  beforeEach(() => {
+    const mockIntersectionObserver = jest.fn();
+    mockIntersectionObserver.mockReturnValue({
+      observe: () => null,
+      unobserve: () => null,
+      disconnect: () => null
+    });
+    window.IntersectionObserver = mockIntersectionObserver;
+  });
+
+  it('renders TopicPageLayout with correct title', () => {
+    renderWithRouter(<DatabasesPage />);
+    expect(screen.getByTestId('topic-page-layout')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Databases' })).toBeInTheDocument();
+  });
+
+  it('renders TopicSidebar with correct title and sections', () => {
+    renderWithRouter(<DatabasesPage />);
+    expect(screen.getByTestId('topic-sidebar')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Databases', level: 2 })).toBeInTheDocument(); // From mock
+
+    expect(screen.getByText('Introduction')).toBeInTheDocument();
+    expect(screen.getByText('SQL Databases')).toBeInTheDocument();
+    expect(screen.getByText('Glossary')).toBeInTheDocument();
+  });
+
+  it('renders the SectionIntroDB by default', () => {
+    renderWithRouter(<DatabasesPage />);
+    expect(screen.getByTestId('intro-db')).toBeInTheDocument();
+  });
+
+  it('switches view when a section in TopicSidebar is clicked', () => {
+    renderWithRouter(<DatabasesPage />);
+    expect(screen.getByTestId('intro-db')).toBeInTheDocument();
+    expect(screen.queryByTestId('sql-db')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('SQL Databases'));
+
+    expect(screen.queryByTestId('intro-db')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sql-db')).toBeInTheDocument();
+    expect(screen.getByText('Current View in Mock: sql')).toBeInTheDocument();
+  });
+
+  it('passes the Sidebar and Content to TopicPageLayout', () => {
+    renderWithRouter(<DatabasesPage />);
+    const sidebarPropContent = screen.getByTestId('sidebar-prop-content');
+    expect(sidebarPropContent.contains(screen.getByTestId('topic-sidebar'))).toBe(true);
+
+    const contentPropContent = screen.getByTestId('content-prop-content');
+    expect(contentPropContent.contains(screen.getByTestId('intro-db'))).toBe(true);
+  });
+});

--- a/system-design-study-app/src/pages/MessagingQueuesPage.test.jsx
+++ b/system-design-study-app/src/pages/MessagingQueuesPage.test.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import MessagingQueuesPage from './MessagingQueuesPage';
+import { BrowserRouter } from 'react-router-dom';
+
+// Mock child components that are not the focus of this test
+jest.mock('../components/common/TopicPageLayout', () => ({ children, sidebar, content, topicTitle }) => (
+  <div data-testid="topic-page-layout">
+    <h1>{topicTitle}</h1>
+    <div data-testid="sidebar-prop-content">{sidebar}</div>
+    <div data-testid="content-prop-content">{content}</div>
+    {children}
+  </div>
+));
+
+jest.mock('../components/common/TopicSidebar', () => ({ topicTitle, sections, currentView, setCurrentView }) => (
+  <div data-testid="topic-sidebar">
+    <h2>{topicTitle}</h2>
+    <ul>
+      {sections.map(section => (
+        <li key={section.id} onClick={() => setCurrentView(section.id)}>
+          {section.title}
+        </li>
+      ))}
+    </ul>
+    <p>Current View in Mock: {currentView}</p>
+  </div>
+));
+
+// Mock view components
+jest.mock('../components/messaging_queues/IntroModuleMQ', () => () => <div data-testid="intro-module-mq">IntroModuleMQ Content</div>);
+jest.mock('../components/messaging_queues/ConceptsModuleMQ', () => () => <div data-testid="concepts-module-mq">ConceptsModuleMQ Content</div>);
+jest.mock('../components/messaging_queues/ArchitecturesModuleMQ', () => () => <div data-testid="architectures-module-mq">ArchitecturesModuleMQ Content</div>);
+jest.mock('../components/messaging_queues/GuaranteesModuleMQ', () => () => <div data-testid="guarantees-module-mq">GuaranteesModuleMQ Content</div>);
+jest.mock('../components/messaging_queues/UseCasesModuleMQ', () => () => <div data-testid="usecases-module-mq">UseCasesModuleMQ Content</div>);
+jest.mock('../components/messaging_queues/TechnologyComparisonMQ', () => () => <div data-testid="tech-comparison-module-mq">TechnologyComparisonMQ Content</div>);
+jest.mock('../components/messaging_queues/ScalabilityModuleMQ', () => () => <div data-testid="scalability-module-mq">ScalabilityModuleMQ Content</div>);
+jest.mock('../components/messaging_queues/ScenariosModuleMQ', () => () => <div data-testid="scenarios-module-mq">ScenariosModuleMQ Content</div>);
+jest.mock('../components/messaging_queues/PracticeModuleMQ', () => () => <div data-testid="practice-module-mq">PracticeModuleMQ Content</div>);
+
+const renderWithRouter = (ui) => {
+  return render(ui, { wrapper: BrowserRouter });
+};
+
+describe('MessagingQueuesPage', () => {
+  beforeEach(() => {
+    // IntersectionObserver isn't available in test environment
+    const mockIntersectionObserver = jest.fn();
+    mockIntersectionObserver.mockReturnValue({
+      observe: () => null,
+      unobserve: () => null,
+      disconnect: () => null
+    });
+    window.IntersectionObserver = mockIntersectionObserver;
+  });
+
+  it('renders TopicPageLayout with correct title', () => {
+    renderWithRouter(<MessagingQueuesPage />);
+    expect(screen.getByTestId('topic-page-layout')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Messaging Queues' })).toBeInTheDocument();
+  });
+
+  it('renders TopicSidebar with correct title and sections', () => {
+    renderWithRouter(<MessagingQueuesPage />);
+    const sidebarMock = screen.getByTestId('topic-sidebar');
+    expect(sidebarMock).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Messaging Queues', level: 2 })).toBeInTheDocument(); // From mock TopicSidebar
+
+    // Check for some section titles
+    expect(screen.getByText('Introduction')).toBeInTheDocument();
+    expect(screen.getByText('Core Concepts')).toBeInTheDocument();
+    expect(screen.getByText('Practice Questions')).toBeInTheDocument();
+  });
+
+  it('renders the IntroModuleMQ by default', () => {
+    renderWithRouter(<MessagingQueuesPage />);
+    expect(screen.getByTestId('intro-module-mq')).toBeInTheDocument();
+  });
+
+  it('switches view when a section in TopicSidebar is clicked', () => {
+    renderWithRouter(<MessagingQueuesPage />);
+
+    // Initial view
+    expect(screen.getByTestId('intro-module-mq')).toBeInTheDocument();
+    expect(screen.queryByTestId('concepts-module-mq')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Core Concepts'));
+
+    expect(screen.queryByTestId('intro-module-mq')).not.toBeInTheDocument();
+    expect(screen.getByTestId('concepts-module-mq')).toBeInTheDocument();
+    expect(screen.getByText('Current View in Mock: core-concepts')).toBeInTheDocument();
+  });
+
+  it('passes the Sidebar and Content to TopicPageLayout', () => {
+    renderWithRouter(<MessagingQueuesPage />);
+
+    const sidebarPropContent = screen.getByTestId('sidebar-prop-content');
+    expect(sidebarPropContent.contains(screen.getByTestId('topic-sidebar'))).toBe(true);
+
+    const contentPropContent = screen.getByTestId('content-prop-content');
+    expect(contentPropContent.contains(screen.getByTestId('intro-module-mq'))).toBe(true);
+  });
+});


### PR DESCRIPTION
- Verified completion of layout and sidebar refactoring (A.2.1, A.2.2).
- Conducted global UI audit (A.2.3), no major layout issues found.
- Added Jest/Vitest test suites for TopicPageLayout, TopicSidebar, MessagingQueuesPage, DatabasesPage, CachesPage, and ApiDesignPage.
- Test files were initially misplaced and then moved to their correct locations within the 'system-design-study-app' directory structure.

Attempted to run tests but encountered persistent issues with directory changes in the bash environment, preventing test execution and verification.