### PR TITLE
Fix: Improve mobile touch targets and header layout

### DIFF
--- a/system-design-study-app/src/components/Layout.jsx
+++ b/system-design-study-app/src/components/Layout.jsx
@@ -39,7 +39,7 @@ const Layout = ({ children }) => {
             >
               <HomeIcon />
             </IconButton>
-            <Typography variant="h6" color="inherit" component="div">
+            <Typography variant="h6" color="inherit" component="div" noWrap sx={{ flexGrow: 1, minWidth: 0 }}>
               System Design Guide
             </Typography>
           </Toolbar>

--- a/system-design-study-app/src/components/common/Button.jsx
+++ b/system-design-study-app/src/components/common/Button.jsx
@@ -75,7 +75,7 @@ const Button = ({
   // Size styles mapping to Tailwind utility classes for padding and text size
   // These should use spacing and fontSize tokens from `tailwind.config.js`
   const sizeStyles = {
-    sm: 'px-3 py-1.5 text-sm', // Uses spacing-3, spacing-1.5 (custom or Tailwind default), fontSize.sm
+    sm: 'px-3 py-3 text-sm min-w-[2.75rem]', // Adjusted for 44px min height/width. py-3 (12px padding top/bottom) + text-sm (20px line-height) = 44px.
     md: 'px-4 py-2 text-base',// Uses spacing-4, spacing-2, fontSize.base
     lg: 'px-6 py-3 text-lg',  // Uses spacing-6, spacing-3, fontSize.lg
   };

--- a/system-design-study-app/src/pages/LoginPage.jsx
+++ b/system-design-study-app/src/pages/LoginPage.jsx
@@ -70,7 +70,7 @@ function LoginPage() {
         </form>
         <p className="mt-6 text-center text-sm text-neutral-600 dark:text-neutral-300">
           Don't have an account?{' '}
-          <Link to="/signup" className="font-medium text-primary hover:text-primary-dark dark:text-primary-light dark:hover:text-primary">
+          <Link to="/signup" className="font-medium text-primary hover:text-primary-dark dark:text-primary-light dark:hover:text-primary inline-block p-3 rounded">
             Sign up
           </Link>
         </p>

--- a/system-design-study-app/src/pages/SignupPage.jsx
+++ b/system-design-study-app/src/pages/SignupPage.jsx
@@ -100,7 +100,7 @@ function SignupPage() {
         </form>
         <p className="mt-6 text-center text-sm text-neutral-600 dark:text-neutral-300">
           Already have an account?{' '}
-          <Link to="/login" className="font-medium text-primary hover:text-primary-dark dark:text-primary-light dark:hover:text-primary">
+          <Link to="/login" className="font-medium text-primary hover:text-primary-dark dark:text-primary-light dark:hover:text-primary inline-block p-3 rounded">
             Log in
           </Link>
         </p>


### PR DESCRIPTION
Sub-task A.3.1: Increase Mobile Touch Target Sizes
- Modified Button component's 'sm' size to ensure a 44x44px minimum touch target.
- Increased padding for text links on Login and Signup pages to meet 44x44px requirement.

Sub-task A.3.2: Resolve Mobile Layout Overlaps
- Adjusted TopicPageLayout header by making the title flexible and enabling truncation. This prevents the page title from overlapping the home icon on narrow screens.