### PR TITLE
Test: Add unit tests for responsive UI fixes

### DIFF
--- a/system-design-study-app/src/components/Layout.test.jsx
+++ b/system-design-study-app/src/components/Layout.test.jsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import Layout from './Layout';
+import { AuthProvider } from '../contexts/AuthContext'; // Assuming AuthProvider might be needed by children
+import { ThemeProvider } from '../contexts/ThemeContext'; // Assuming ThemeProvider might be needed
+import '@testing-library/jest-dom';
+
+// Mock Sidebar as it's complex and not the focus of this specific test
+vi.mock('./Sidebar', () => ({
+  default: () => <div data-testid="mock-sidebar">Mock Sidebar</div>,
+}));
+
+// Mock MUI components that are not directly under test but are part of Layout
+vi.mock('@mui/material', async () => {
+  const actualMui = await vi.importActual('@mui/material');
+  return {
+    ...actualMui,
+    AppBar: ({ children, ...props }) => <header {...props}>{children}</header>,
+    Toolbar: ({ children, ...props }) => <div {...props}>{children}</div>,
+    IconButton: ({ children, ...props }) => <button {...props}>{children}</button>,
+    Typography: ({ children, noWrap, sx, ...props }) => (
+      <div
+        data-testid="mock-typography"
+        data-nowrap={noWrap ? 'true' : 'false'}
+        data-sx={JSON.stringify(sx)}
+        {...props}
+      >
+        {children}
+      </div>
+    ),
+    Box: ({ children, sx, ...props }) => (
+      <div data-testid="mock-box" data-sx={JSON.stringify(sx)} {...props}>
+        {children}
+      </div>
+    ),
+  };
+});
+vi.mock('@mui/icons-material/Home', () => ({
+  default: () => <span data-testid="mock-home-icon">HomeIcon</span>,
+}));
+
+
+describe('Layout Component', () => {
+  // Helper function to render Layout with a specific route
+  const renderLayoutAtRoute = (route) => {
+    return render(
+      <MemoryRouter initialEntries={[route]}>
+        <ThemeProvider> {/* Assuming ThemeContext is used */}
+          <AuthProvider> {/* Assuming AuthContext is used */}
+            <Layout>
+              <div>Page Content</div>
+            </Layout>
+          </AuthProvider>
+        </ThemeProvider>
+      </MemoryRouter>
+    );
+  };
+
+  test('renders Sidebar and children for non-topic pages', () => {
+    renderLayoutAtRoute('/');
+    expect(screen.getByTestId('mock-sidebar')).toBeInTheDocument();
+    expect(screen.getByText('Page Content')).toBeInTheDocument();
+  });
+
+  describe('TopicPageLayout specific tests', () => {
+    // Test one of the topic page paths
+    const topicRoute = '/caches';
+
+    test('renders minimal header with HomeIcon and title for topic pages', () => {
+      renderLayoutAtRoute(topicRoute);
+      expect(screen.getByTestId('mock-home-icon')).toBeInTheDocument();
+      expect(screen.getByText('System Design Guide')).toBeInTheDocument();
+      expect(screen.queryByTestId('mock-sidebar')).not.toBeInTheDocument(); // Sidebar should not be present
+    });
+
+    test('Typography for title in TopicPageLayout has correct props for truncation and flexibility', () => {
+      renderLayoutAtRoute(topicRoute);
+
+      // Find all mock typography components
+      const typographyElements = screen.getAllByTestId('mock-typography');
+      // Find the one that contains the title text
+      const titleTypography = typographyElements.find(el => el.textContent === 'System Design Guide');
+
+      expect(titleTypography).toBeInTheDocument();
+      expect(titleTypography).toHaveAttribute('data-nowrap', 'true'); // Check noWrap prop
+
+      const sxProps = JSON.parse(titleTypography.getAttribute('data-sx'));
+      expect(sxProps).toEqual(expect.objectContaining({
+        flexGrow: 1,
+        minWidth: 0,
+      }));
+    });
+  });
+});

--- a/system-design-study-app/src/components/common/Button.test.jsx
+++ b/system-design-study-app/src/components/common/Button.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import Button from './Button'; // Assuming Button.jsx is in the same directory
+import '@testing-library/jest-dom';
+
+describe('Button Component', () => {
+  test('applies correct classes for "sm" size to meet touch target requirements', () => {
+    render(<Button size="sm">Small Button</Button>);
+    const buttonElement = screen.getByRole('button', { name: /small button/i });
+
+    // Check for padding classes (py-3)
+    // Note: Tailwind might compile this to a single class, or apply multiple.
+    // A more robust check might be to verify computed styles if possible,
+    // but class checking is a good first step for Tailwind.
+    expect(buttonElement).toHaveClass('py-3');
+
+    // Check for min-width class (min-w-[2.75rem])
+    // The actual class name might be different after Tailwind compilation.
+    // This assertion might need adjustment based on how Tailwind handles arbitrary values in classes.
+    // A more direct way if Tailwind generates a specific class:
+    // expect(buttonElement).toHaveClass('min-w-[2.75rem]');
+    // Or, if checking inline styles (less common for Tailwind utility-first):
+    // expect(buttonElement.style.minWidth).toBe('2.75rem');
+
+    // For now, let's check for the presence of a class that implies min-width.
+    // This is a placeholder as direct class name for arbitrary values can be tricky.
+    // We're checking if our intended utility 'min-w-[2.75rem]' is part of the className string.
+    // This is not ideal as it might match substrings, but it's a start without computed styles.
+    const classList = buttonElement.className;
+    expect(classList).toContain('min-w-[2.75rem]');
+    expect(classList).toContain('text-sm'); // also check for text size
+  });
+
+  test('applies primary variant styles correctly', () => {
+    render(<Button variant="primary">Primary Button</Button>);
+    const buttonElement = screen.getByRole('button', { name: /primary button/i });
+    expect(buttonElement).toHaveClass('bg-primary');
+    expect(buttonElement).toHaveClass('text-white');
+  });
+
+  test('renders children correctly', () => {
+    render(<Button>Click Me</Button>);
+    expect(screen.getByRole('button', { name: /click me/i })).toBeInTheDocument();
+  });
+
+  test('handles onClick event', () => {
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Clickable</Button>);
+    const buttonElement = screen.getByRole('button', { name: /clickable/i });
+    fireEvent.click(buttonElement);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/system-design-study-app/src/pages/LoginPage.test.jsx
+++ b/system-design-study-app/src/pages/LoginPage.test.jsx
@@ -58,4 +58,10 @@ describe('LoginPage', () => {
     expect(errorMessage).toHaveAttribute('role', 'alert');
     expect(errorMessage).toHaveAttribute('id', 'form-error-message');
   });
+
+  test('Sign up link has increased touch target padding', () => {
+    renderComponent();
+    const signupLink = screen.getByRole('link', { name: /sign up/i });
+    expect(signupLink).toHaveClass('p-3');
+  });
 });

--- a/system-design-study-app/src/pages/SignupPage.test.jsx
+++ b/system-design-study-app/src/pages/SignupPage.test.jsx
@@ -86,4 +86,10 @@ describe('SignupPage', () => {
     expect(errorMessage).toHaveAttribute('role', 'alert');
     expect(errorMessage).toHaveAttribute('id', 'form-error-message');
   });
+
+  test('Log in link has increased touch target padding', () => {
+    renderComponent();
+    const loginLink = screen.getByRole('link', { name: /log in/i });
+    expect(loginLink).toHaveClass('p-3');
+  });
 });


### PR DESCRIPTION
- Add tests for Button component's 'sm' size to verify padding and min-width for touch target compliance.
- Add tests for Layout component (TopicPageLayout) to verify title's Typography props (noWrap, flexGrow, minWidth) for preventing overlap.
- Add tests to LoginPage and SignupPage to verify increased padding on navigation links.