### PR TITLE
Fix layout tests

### DIFF
--- a/system-design-study-app/src/components/Layout.test.jsx
+++ b/system-design-study-app/src/components/Layout.test.jsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import Layout from './Layout';
 import { AuthProvider } from '../contexts/AuthContext'; // Assuming AuthProvider might be needed by children
-import { ThemeProvider } from '../contexts/ThemeContext'; // Assuming ThemeProvider might be needed
+import { CustomThemeProvider } from '../contexts/ThemeContext'; // Import the actual provider
 import '@testing-library/jest-dom';
 
 // Mock Sidebar as it's complex and not the focus of this specific test
@@ -49,13 +49,13 @@ describe('Layout Component', () => {
   const renderLayoutAtRoute = (route) => {
     return render(
       <MemoryRouter initialEntries={[route]}>
-        <ThemeProvider> {/* Assuming ThemeContext is used */}
+        <CustomThemeProvider> {/* Provide theme context */}
           <AuthProvider> {/* Assuming AuthContext is used */}
             <Layout>
               <div>Page Content</div>
             </Layout>
           </AuthProvider>
-        </ThemeProvider>
+        </CustomThemeProvider>
       </MemoryRouter>
     );
   };

--- a/system-design-study-app/src/components/common/TopicPageLayout.test.jsx
+++ b/system-design-study-app/src/components/common/TopicPageLayout.test.jsx
@@ -36,15 +36,18 @@ describe('TopicPageLayout', () => {
         <TopicPageLayout
           SidebarComponent={MockSidebarComponent}
           renderViewFunction={mockRenderViewFunction}
-        pageTitle="Test Topic Page"
-        appData={mockAppData}
-        initialView="testView"
-        topicId="test-topic"
-      />
+          pageTitle="Test Topic Page"
+          appData={mockAppData}
+          initialView="testView"
+          topicId="test-topic"
+        />
+      </MemoryRouter>
     );
 
-    expect(screen.getByTestId('sidebar')).toBeInTheDocument();
-    expect(screen.getByText('Sidebar Content')).toBeInTheDocument();
+    // There are two sidebars rendered (temporary & permanent drawers)
+    const sidebars = screen.getAllByTestId('sidebar');
+    expect(sidebars.length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Sidebar Content').length).toBeGreaterThan(0);
     expect(screen.getByTestId('rendered-view')).toBeInTheDocument();
     expect(screen.getByText('Rendered View Content')).toBeInTheDocument();
     expect(screen.getByText('Test Topic Page')).toBeInTheDocument(); // Checks AppBar title
@@ -58,11 +61,12 @@ describe('TopicPageLayout', () => {
         <TopicPageLayout
           SidebarComponent={MockSidebarComponent}
           renderViewFunction={mockRenderViewFunction}
-        pageTitle="Test Topic with AI"
-        appData={{}}
-        initialView="default"
-        topicId="ai-topic"
-      />
+          pageTitle="Test Topic with AI"
+          appData={{}}
+          initialView="default"
+          topicId="ai-topic"
+        />
+      </MemoryRouter>
     );
 
     const fabButton = screen.getByRole('button', { name: 'ask ai' }); // Changed regex to string


### PR DESCRIPTION
## Summary
- handle multiple sidebars in TopicPageLayout tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b1324dfcc8330b6239768290c18e9