### PR TITLE
Add disabled state test for Button

### DIFF
--- a/system-design-study-app/src/components/common/Button.test.jsx
+++ b/system-design-study-app/src/components/common/Button.test.jsx
@@ -49,4 +49,17 @@ describe('Button Component', () => {
     fireEvent.click(buttonElement);
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  test('does not trigger onClick when disabled', () => {
+    const handleClick = vi.fn();
+    render(
+      <Button disabled onClick={handleClick}>
+        Disabled
+      </Button>
+    );
+    const buttonElement = screen.getByRole('button', { name: /disabled/i });
+    expect(buttonElement).toBeDisabled();
+    fireEvent.click(buttonElement);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- add test verifying disabled prop prevents handler call

## Testing
- `npm test --prefix system-design-study-app`

------
https://chatgpt.com/codex/tasks/task_e_685b17e02d1883309ce7613b9887675a