### PR TITLE
fix: Resolve AppBar visibility on topic pages and theme issues

### DIFF
--- a/system-design-study-app/src/components/common/TopicPageLayout.jsx
+++ b/system-design-study-app/src/components/common/TopicPageLayout.jsx
@@ -39,15 +39,18 @@ function TopicPageLayout({
   return (
     <Box sx={{ display: 'flex' }}>
       <CssBaseline />
+      {/* This AppBar is for the content within TopicPageLayout, not the main site AppBar */}
       <AppBar
-        position="fixed"
+        position="sticky" // Changed from "fixed"
         sx={(theme) => ({
+          top: 0, // Stick to the top of its scrolling container
           width: { sm: `calc(100% - ${drawerWidth}px)` },
           ml: { sm: `${drawerWidth}px` },
           backgroundColor: alpha(theme.palette.background.default, 0.85),
           backdropFilter: 'blur(8px)',
           boxShadow: theme.shadows[1],
           color: 'text.primary',
+          zIndex: theme.zIndex.appBar - 100 // Lower zIndex than main AppBar
         })}
       >
         <Toolbar>


### PR DESCRIPTION
- Modified TopicPageLayout's internal AppBar to be position:sticky with top:0 and a zIndex lower than the main Layout AppBar, preventing it from obscuring the main site navigation.
- Ensured main Layout AppBar has appropriate zIndex.
- Removed hardcoded 'dark' class from index.html, allowing ThemeContext to control the initial theme state correctly.
- Corrected theme toggle functionality in Layout.jsx by properly connecting to ThemeContext and using themeMode for icon display.
- Updated Layout.jsx and HomePage.jsx to use theme-aware palette colors for better color transitions.
- Ensured CustomThemeProvider is correctly used in Layout.test.jsx.
- All tests pass. AppBar visibility and theme switching are now functioning as expected across the site.