### PR TITLE
debug: Add diagnostics for topic page content visibility

### DIFF
--- a/system-design-study-app/src/components/common/TopicPageLayout.jsx
+++ b/system-design-study-app/src/components/common/TopicPageLayout.jsx
@@ -126,6 +126,14 @@ function TopicPageLayout({
         }}
       >
         <Toolbar />
+        <div style={{ border: '2px solid green', padding: '10px', margin: '10px', backgroundColor: 'lightgreen', color: 'black' }}>
+          <Typography><strong>Diagnostic Info:</strong></Typography>
+          <Typography>Current View Prop (for Sidebar): {currentView}</Typography>
+          <Typography>Initial View Prop (from page): {initialView}</Typography>
+          <Typography>Topic ID: {topicId}</Typography>
+          <Typography>Page Title: {pageTitle}</Typography>
+          <Typography>appData available: {appData ? 'Yes' : 'No'}</Typography>
+        </div>
         <Suspense fallback={
           <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 'calc(100vh - 112px)' }}>
             <CircularProgress size={60} />


### PR DESCRIPTION
- Added a diagnostic div within TopicPageLayout's main content area to display currentView, initialView, topicId, pageTitle, and appData status. This is to help debug why content might not be visible on topic pages.
- Reverted FundamentalsView.jsx to its original content (after temporary simplification for testing).
- Fine-tuned TopicSidebar's top offset in TopicPageLayout to use a fixed '64px' and height 'calc(100vh - 64px)' for better alignment under the main AppBar.
- All tests pass with these changes.

This commit is for diagnostic purposes to gather more information on the content visibility issue.