### PR TITLE
debug: Drastically simplify TopicPageLayout to a minimal stub for tes…

### DIFF
--- a/system-design-study-app/src/components/common/TopicPageLayout.jsx
+++ b/system-design-study-app/src/components/common/TopicPageLayout.jsx
@@ -1,162 +1,39 @@
-import React, { useState, Suspense, useEffect } from 'react';
-import { Link } from 'react-router-dom';
-import { Box, Drawer, AppBar, Toolbar, IconButton, Typography, CircularProgress, Fab, CssBaseline } from '@mui/material';
-import { alpha } from '@mui/material/styles';
-import MenuIcon from '@mui/icons-material/Menu';
-import HomeIcon from '@mui/icons-material/Home';
-import LightbulbIcon from '@mui/icons-material/Lightbulb';
-import AiScenarioModal from './AiScenarioModal';
+import React from 'react';
+import { Box, Typography } from '@mui/material';
 
-const drawerWidth = 240;
-
-function TopicPageLayout({
-  pageTitle,
-  SidebarComponent,
-  renderViewFunction,
-  initialView = 'fundamentals',
-  appData,
-  topicId
-}) {
-  const [mobileOpen, setMobileOpen] = useState(false);
-  const [currentView, setCurrentView] = useState(initialView);
-  const [isAiModalOpenForTopic, setIsAiModalOpenForTopic] = useState(false);
-
-  const handleDrawerToggle = () => {
-    setMobileOpen(!mobileOpen);
-  };
-
-  const mockSubmitToBackend = async (problem, solution) => {
-    console.log(`Simulating Firebase call to 'getAiFeedback' with:`);
-    console.log("Topic:", pageTitle);
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    return `Mock AI feedback for topic '${pageTitle}'. Real LLM integration pending.`;
-  };
-
-  useEffect(() => {
-    setCurrentView(initialView);
-  }, [initialView, topicId]);
+// Ultra-Minimal Stub for TopicPageLayout
+function TopicPageLayout({ pageTitle, topicId, initialView, appData, SidebarComponent, renderViewFunction }) {
+  // Log all props to see what CachesPage is trying to pass
+  console.log('MINIMAL STUB TopicPageLayout - Props Received:', { pageTitle, topicId, initialView, appData: !!appData, SidebarComponent: !!SidebarComponent, renderViewFunction: !!renderViewFunction });
 
   return (
-    <Box sx={{ display: 'flex', width: '100%', height: '100%' }}> {/* Ensure root takes space */}
-      <CssBaseline />
-      {/* Temporarily comment out inner AppBar and Nav Box (Drawers) to isolate main content Box */}
-      {/*
-      <AppBar
-        position="sticky"
-        sx={(theme) => ({
-          top: 0,
-          width: { sm: `calc(100% - ${drawerWidth}px)` },
-          ml: { sm: `${drawerWidth}px` },
-          backgroundColor: alpha(theme.palette.background.default, 0.85),
-          backdropFilter: 'blur(8px)',
-          boxShadow: theme.shadows[1],
-          color: 'text.primary',
-          zIndex: theme.zIndex.appBar - 100
-        })}
-      >
-        <Toolbar>
-          <IconButton
-            color="inherit"
-            aria-label="open drawer"
-            edge="start"
-            onClick={handleDrawerToggle}
-            sx={{ mr: 2, display: { sm: 'none' } }}
-          >
-            <MenuIcon />
-          </IconButton>
-          <IconButton
-            color="inherit"
-            aria-label="go home"
-            component={Link}
-            to="/"
-            sx={{ display: { xs: 'none', sm: 'inline-flex' }, mr: 2 }}
-          >
-            <HomeIcon />
-          </IconButton>
-          <Typography variant="h6" noWrap component="div">
-            {pageTitle}
-          </Typography>
-        </Toolbar>
-      </AppBar>
-      <Box
-        component="nav"
-        sx={{ width: { sm: drawerWidth }, flexShrink: { sm: 0 } }}
-        aria-label={`${pageTitle} sections sidebar`}
-      >
-        <Drawer
-          variant="temporary"
-          open={mobileOpen}
-          onClose={handleDrawerToggle}
-          ModalProps={{ keepMounted: true }}
-          sx={{
-            display: { xs: 'block', sm: 'none' },
-            '& .MuiDrawer-paper': { boxSizing: 'border-box', width: drawerWidth, bgcolor: 'background.paper' },
-          }}
-        >
-          <SidebarComponent currentView={currentView} setCurrentView={setCurrentView} />
-        </Drawer>
-        <Drawer
-          variant="permanent"
-          sx={(theme) => ({
-            display: { xs: 'none', sm: 'block' },
-            '& .MuiDrawer-paper': {
-              boxSizing: 'border-box',
-              width: drawerWidth,
-              bgcolor: 'background.paper',
-              borderRight: 'none',
-              top: '64px',
-              height: 'calc(100vh - 64px)',
-            },
-          })}
-          open
-        >
-          <SidebarComponent currentView={currentView} setCurrentView={setCurrentView} />
-        </Drawer>
-      </Box>
-      */}
-      <Box
-        component="main"
-        sx={{
-          flexGrow: 1,
-          p: 3,
-          bgcolor: 'background.paper', // Use theme-aware background color
-          border: '5px dashed blue',     // Added border for visibility
-          minHeight: 'calc(100vh - 150px)', // Added minHeight to ensure it takes space
-        }}
-      >
-        <Toolbar />
-        <div style={{ border: '2px solid green', padding: '10px', margin: '10px', backgroundColor: 'lightgreen', color: 'black' }}>
-          <Typography><strong>Diagnostic Info:</strong></Typography>
-          <Typography>Current View Prop (for Sidebar): {currentView}</Typography>
-          <Typography>Initial View Prop (from page): {initialView}</Typography>
-          <Typography>Topic ID: {topicId}</Typography>
-          <Typography>Page Title: {pageTitle}</Typography>
-          <Typography>appData available: {appData ? 'Yes' : 'No'}</Typography>
-        </div>
-        {/* Re-enabled Suspense to test with MinimalLazyTestView */}
-        <Suspense fallback={
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: 'calc(100vh - 112px)' }}>
-            <CircularProgress size={60} />
-          </Box>
-        }>
-          {renderViewFunction(currentView, appData)}
-        </Suspense>
-        <Fab
-          color="secondary"
-          aria-label="ask ai"
-          onClick={() => setIsAiModalOpenForTopic(true)}
-          sx={{ position: 'fixed', bottom: 32, right: 32 }}
-        >
-          <LightbulbIcon />
-        </Fab>
-      </Box>
-
-      <AiScenarioModal
-        isOpen={isAiModalOpenForTopic}
-        onClose={() => setIsAiModalOpenForTopic(false)}
-        topicTitle={pageTitle}
-        onSubmitToBackend={mockSubmitToBackend}
-      />
+    <Box
+      sx={{
+        width: 'calc(100% - 40px)', // To ensure it's not full bleed and noticeable
+        minHeight: '400px',
+        border: '10px solid limegreen',
+        p: 3,
+        m: '20px', // Margin to pull it away from edges
+        mt: '84px', // Margin top to clear main AppBar (64px) + some extra
+        bgcolor: 'lightyellow'
+      }}
+      data-testid="topic-page-layout-stub"
+    >
+      <Typography variant="h2" sx={{ color: 'green', fontWeight: 'bold' }}>
+        LIME GREEN BOX - TOPIC PAGE LAYOUT STUB
+      </Typography>
+      <Typography variant="h4" sx={{ color: 'darkgreen', mt: 2 }}>
+        Page Title Prop Received: {pageTitle}
+      </Typography>
+      <Typography sx={{ color: 'darkgreen', mt: 1 }}>
+        If you see this, CachesPage is rendering this TopicPageLayout stub.
+      </Typography>
+      <Typography sx={{ color: 'blue', mt: 1 }}>
+        (Original Sidebar and Content would be here - currentView logic removed for this stub)
+      </Typography>
+      <Typography sx={{ color: 'blue', mt: 1 }}>
+        (Actual appData is {appData ? 'present' : 'NOT present'})
+      </Typography>
     </Box>
   );
 }


### PR DESCRIPTION
…ting

- Overwrote TopicPageLayout.jsx with an ultra-minimal version (the "Lime Box Test") that only displays a lime green bordered box with static text and the pageTitle prop.
- This version has NO internal AppBar, Drawer, Suspense, or complex logic.
- CachesPage.jsx still passes props to it, but TopicPageLayout (stub) will ignore most of them. MinimalLazyTestView is NOT rendered by this stub.

This is to definitively test if CachesPage can render TopicPageLayout at all and if TopicPageLayout can render any minimal content in its place.

Expected test failures in CachesPage.test.jsx and TopicPageLayout.test.jsx due to these changes. MermaidDiagram.test.jsx timeouts still ignored.