### PR TITLE
Diag: Test Cachepedia rendering and fix typo

### DIFF
--- a/system-design-study-app/src/components/caches/CachepediaView.jsx
+++ b/system-design-study-app/src/components/caches/CachepediaView.jsx
@@ -155,7 +155,7 @@ const CachepediaView = ({ appData }) => {
                   {selectedCache.cons.map((con, i) => <li key={i}>{con}</li>)}
                 </ul>
               </div>
-              <p className="text-base text-neutral-600 dark:text-neutral-400"><strong className="font-semibold text-neutral-700 dark:text-neutral-200">Ideal Use Cases:</strong> {selectedCache.useWhen}</p>
+              <p className="text-base text-neutral-600 dark:text-neutral-400"><strong className="font-semibold text-neutral-700 dark:text-neutral-200">Ideal Use Cases:</strong> {selectedCache.whenToUse}</p>
             </div>
 
             <Card

--- a/system-design-study-app/src/pages/CachesPage.jsx
+++ b/system-design-study-app/src/pages/CachesPage.jsx
@@ -21,7 +21,8 @@ const renderCachesView = (currentView, data) => {
     case 'fundamentals':
       return <FundamentalsView {...commonProps} />;
     case 'cachepedia':
-      return <CachepediaView {...commonProps} />;
+      // return <CachepediaView {...commonProps} />; // Original
+      return <div data-testid="cachepedia-test-content">CACHE PEDIA TEST VIEW VIA DIV</div>; // Diagnostic
     case 'patterns':
       return <PatternsView {...commonProps} />;
     case 'scenarios':


### PR DESCRIPTION
- Temporarily replaced CachepediaView in CachesPage.jsx with a simple div for diagnostic purposes to test content area rendering.
- Fixed a typo in CachepediaView.jsx (useWhen to whenToUse).

This commit is for diagnostic testing by the user.