### PR TITLE
Revert: Restore standard MUI createTheme import

### DIFF
--- a/system-design-study-app/src/styles/muiThemes.js
+++ b/system-design-study-app/src/styles/muiThemes.js
@@ -1,5 +1,4 @@
-// import { createTheme } from '@mui/material/styles'; // Original
-import createTheme from '@mui/material/styles/createTheme'; // Attempting direct import
+import { createTheme } from '@mui/material/styles'; // Reverted to standard named import
 import tailwindConfig from '../../tailwind.config.js'; // Adjust path as necessary
 
 // Helper function to parse Tailwind fontSize array [size, {lineHeight}]


### PR DESCRIPTION
Reverted the import for `createTheme` in `muiThemes.js` back to the standard named import (`import { createTheme } from '@mui/material/styles';`).

This is to ensure the most common and standard import is used, as alternative import paths did not resolve the user's local `createTheme_default` runtime error. Further troubleshooting on the user's local environment (clearing node_modules, lock files, reinstalling) is recommended.