### PR TITLE
Revert: Update TopicPageLayout useEffect dependencies

### DIFF
--- a/system-design-study-app/src/components/common/TopicPageLayout.jsx
+++ b/system-design-study-app/src/components/common/TopicPageLayout.jsx
@@ -34,7 +34,7 @@ function TopicPageLayout({
 
   useEffect(() => {
     setCurrentView(initialView);
-  }, [topicId]); // Only depend on topicId to reset view when the topic changes
+  }, [initialView, topicId]);
 
   return (
     <Box sx={{ display: 'flex', width: '100%', height: '100%' }}>


### PR DESCRIPTION
Reverted the useEffect dependency array in TopicPageLayout.jsx back to [initialView, topicId].

This is an attempt to address content rendering issues by restoring the hook to a common prior configuration, following the resolution of a separate MUI theming error.