### PR TITLE
Refactor: Move inline sidebar definitions in topic pages

### DIFF
--- a/system-design-study-app/src/components/apidesign/ApiDesignPage.jsx
+++ b/system-design-study-app/src/components/apidesign/ApiDesignPage.jsx
@@ -47,16 +47,17 @@ const apiDesignSidebarSections = [
   { id: 'practice', title: 'Practice Questions' },
 ];
 
-function ApiDesignPage() {
-  const SidebarComponentWithProps = (props) => (
-    <TopicSidebar
-      topicTitle="API Design Topics" // Pass the topic title
-      sections={apiDesignSidebarSections} // Pass the sections data
-      currentView={props.currentView}
-      setCurrentView={props.setCurrentView}
-    />
-  );
+// Moved SidebarComponentWithProps outside the ApiDesignPage component
+const SidebarComponentWithProps = (props) => (
+  <TopicSidebar
+    topicTitle="API Design Topics" // Pass the topic title
+    sections={apiDesignSidebarSections} // Pass the sections data
+    currentView={props.currentView}
+    setCurrentView={props.setCurrentView}
+  />
+);
 
+function ApiDesignPage() {
   return (
     <TopicPageLayout
       pageTitle="API Design"

--- a/system-design-study-app/src/components/loadbalancing/LoadBalancingPage.jsx
+++ b/system-design-study-app/src/components/loadbalancing/LoadBalancingPage.jsx
@@ -43,16 +43,17 @@ const loadBalancingSidebarSections = [
   { id: 'practice', title: 'Practice Questions' },
 ];
 
-function LoadBalancingPage() {
-  const SidebarComponentWithProps = (props) => (
-    <TopicSidebar
-      topicTitle="Load Balancing" // Title for the sidebar
-      sections={loadBalancingSidebarSections} // Pass the sections data
-      currentView={props.currentView}
-      setCurrentView={props.setCurrentView}
-    />
-  );
+// Moved SidebarComponentWithProps outside the LoadBalancingPage component
+const SidebarComponentWithProps = (props) => (
+  <TopicSidebar
+    topicTitle="Load Balancing" // Title for the sidebar
+    sections={loadBalancingSidebarSections} // Pass the sections data
+    currentView={props.currentView}
+    setCurrentView={props.setCurrentView}
+  />
+);
 
+function LoadBalancingPage() {
   return (
     <TopicPageLayout
       pageTitle="Load Balancing"

--- a/system-design-study-app/src/pages/CachesPage.jsx
+++ b/system-design-study-app/src/pages/CachesPage.jsx
@@ -48,6 +48,16 @@ const cacheSidebarSections = [
   { id: 'code', title: 'Code Library' },
 ];
 
+// Moved SidebarComponentWithProps outside the CachesPage component
+const SidebarComponentWithProps = (props) => (
+  <TopicSidebar
+    topicTitle="Caching Topics" // Pass the topic title
+    sections={cacheSidebarSections} // Pass the sections data
+    currentView={props.currentView}
+    setCurrentView={props.setCurrentView}
+  />
+);
+
 function CachesPage() {
   const pageTitle = "Caching Strategies | System Design Interview Prep";
   const pageDescription = "Master caching techniques, patterns, and trade-offs for high-performance systems. Learn about cache invalidation, eviction policies, and more.";
@@ -72,15 +82,6 @@ function CachesPage() {
       metaTags.forEach(tag => removeMetaTag(tag.name, tag.isProperty));
     };
   }, [pageTitle, pageDescription]);
-
-  const SidebarComponentWithProps = (props) => (
-    <TopicSidebar
-      topicTitle="Caching Topics" // Pass the topic title
-      sections={cacheSidebarSections} // Pass the sections data
-      currentView={props.currentView}
-      setCurrentView={props.setCurrentView}
-    />
-  );
 
   return (
     <>

--- a/system-design-study-app/src/pages/DatabasesPage.jsx
+++ b/system-design-study-app/src/pages/DatabasesPage.jsx
@@ -49,6 +49,16 @@ const databaseSidebarSections = [
     { id: 'summary', title: 'DB Comparison Summary' },
 ];
 
+// Moved SidebarComponentWithProps outside the DatabasesPage component
+const SidebarComponentWithProps = (props) => (
+  <TopicSidebar
+    topicTitle="Database Topics" // Pass the topic title
+    sections={databaseSidebarSections} // Pass the sections data
+    currentView={props.currentView}
+    setCurrentView={props.setCurrentView}
+  />
+);
+
 function DatabasesPage() {
   const pageTitle = "Database Selection | System Design Interview Prep";
   const pageDescription = "Learn to choose the right database (SQL vs. NoSQL), understand the CAP theorem, and explore various data models for system design interviews.";
@@ -73,15 +83,6 @@ function DatabasesPage() {
       metaTags.forEach(tag => removeMetaTag(tag.name, tag.isProperty));
     };
   }, [pageTitle, pageDescription]);
-
-  const SidebarComponentWithProps = (props) => (
-    <TopicSidebar
-      topicTitle="Database Topics" // Pass the topic title
-      sections={databaseSidebarSections} // Pass the sections data
-      currentView={props.currentView}
-      setCurrentView={props.setCurrentView}
-    />
-  );
 
   return (
     <>

--- a/system-design-study-app/src/pages/MessagingQueuesPage.jsx
+++ b/system-design-study-app/src/pages/MessagingQueuesPage.jsx
@@ -57,6 +57,16 @@ const mqSidebarSections = [
   { id: 'practice', title: 'Practice Questions' },
 ];
 
+// Moved SidebarComponentWithProps outside the MessagingQueuesPage component
+const SidebarComponentWithProps = (props) => (
+  <TopicSidebar
+    topicTitle="Messaging Queues"
+    sections={mqSidebarSections}
+    currentView={props.currentView}
+    setCurrentView={props.setCurrentView}
+  />
+);
+
 function MessagingQueuesPage() {
   const pageTitle = "Messaging Queues | System Design Interview Prep";
   const pageDescription = "Explore message brokers, delivery semantics, and patterns for resilient and scalable distributed systems. Learn about Kafka, RabbitMQ, and more.";
@@ -81,15 +91,6 @@ function MessagingQueuesPage() {
       metaTags.forEach(tag => removeMetaTag(tag.name, tag.isProperty));
     };
   }, [pageTitle, pageDescription]);
-
-  const SidebarComponentWithProps = (props) => (
-    <TopicSidebar
-      topicTitle="Messaging Queues"
-      sections={mqSidebarSections}
-      currentView={props.currentView}
-      setCurrentView={props.setCurrentView}
-    />
-  );
 
   return (
     <>


### PR DESCRIPTION
Moved inline sidebar component definitions (e.g., SidebarComponentWithProps) to the module level in multiple topic pages:
- CachesPage.jsx
- DatabasesPage.jsx
- ApiDesignPage.jsx
- LoadBalancingPage.jsx
- MessagingQueuesPage.jsx

This fixes an anti-pattern where new component types were passed as props on every render, causing TopicPageLayout to potentially re-mount and reset its state, leading to content rendering issues.

This change, combined with previous fixes for MUI theme initialization and TopicPageLayout useEffect, should resolve the sub-topic content loading problems.