### PR TITLE
Fix: Remove duplicate alpha import in muiThemes.js

### DIFF
--- a/system-design-study-app/src/styles/muiThemes.js
+++ b/system-design-study-app/src/styles/muiThemes.js
@@ -1,8 +1,4 @@
-import { createTheme } from '@mui/material/styles';
-
-import { alpha } from '@mui/material/styles';
-
-import { alpha } from '@mui/material/styles';
+import { createTheme, alpha } from '@mui/material/styles';
 
 // Fallback color values (from your CSS variables)
 const FALLBACK_ACCENT_PRIMARY = '#4FD1C5';


### PR DESCRIPTION
This commit removes a redundant import statement for the `alpha` utility from `@mui/material/styles` in `src/styles/muiThemes.js`.

The duplicate import was causing a runtime SyntaxError: "Identifier 'alpha' has already been declared".