### PR TITLE
Fix: Separate MUI utility imports in muiThemes.js

### DIFF
--- a/system-design-study-app/src/styles/muiThemes.js
+++ b/system-design-study-app/src/styles/muiThemes.js
@@ -1,4 +1,5 @@
-import { createTheme, alpha } from '@mui/material/styles';
+import { createTheme } from '@mui/material/styles';
+import { alpha } from '@mui/material/styles';
 
 // Fallback color values (from your CSS variables)
 const FALLBACK_ACCENT_PRIMARY = '#4FD1C5';


### PR DESCRIPTION
Reverted the combined import of `createTheme` and `alpha` from `@mui/material/styles` to separate import statements.

This is an attempt to resolve a runtime error (`TypeError: createTheme_default is not a function`) that might be related to how the build tool processes combined imports for this specific module.