### PR TITLE
Attempt to fix MUI createTheme error with Vite optimizeDeps

### DIFF
--- a/system-design-study-app/src/styles/muiThemes.js
+++ b/system-design-study-app/src/styles/muiThemes.js
@@ -1,5 +1,4 @@
-import { createTheme } from '@mui/material/styles';
-import { alpha } from '@mui/material/styles';
+import { createTheme, alpha } from '@mui/material/styles';
 
 // Fallback color values (from your CSS variables)
 const FALLBACK_ACCENT_PRIMARY = '#4FD1C5';

--- a/system-design-study-app/vite.config.js
+++ b/system-design-study-app/vite.config.js
@@ -4,6 +4,17 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  optimizeDeps: {
+    include: [
+      '@mui/material/styles',
+      '@mui/material/utils',
+      '@mui/material/colors',
+      '@mui/material/Button', // Example: include if specific components cause issues
+      // You might need to add other specific MUI component paths if issues persist
+      // e.g. '@mui/material/AppBar', '@mui/material/Card', etc.
+      // or even broader like '@mui/material' if necessary, though more targeted is better.
+    ],
+  },
   build: {
     rollupOptions: {
       external: ['mermaid'], // Tell Rollup that 'mermaid' is external


### PR DESCRIPTION
- Added various @mui/material paths to `optimizeDeps.include` in `vite.config.js`.
- Reverted muiThemes.js to use standard combined imports for `createTheme` and `alpha` from `@mui/material/styles` as specific path imports caused test failures.

The runtime error `TypeError: createTheme_default is not a function` may persist and likely requires further, more specialized investigation into Vite's build process or specific MUI compatibility with Vite's bundling for the version in use if this change doesn't resolve it.