### PR TITLE
Force theme text colors in HomePage hero and titles

### DIFF
--- a/system-design-study-app/src/pages/HomePage.jsx
+++ b/system-design-study-app/src/pages/HomePage.jsx
@@ -46,7 +46,7 @@ const HomePage = () => {
       <Box
         sx={{
           // bgcolor removed to use page default
-          color: 'var(--text-primary)',   // Ensure text color is theme-aware
+          color: 'var(--text-primary) !important',   // Ensure text color is theme-aware
           py: { xs: 6, sm: 8, md: 10 },
           textAlign: 'center',
         }}
@@ -60,7 +60,7 @@ const HomePage = () => {
               fontWeight: 'bold',
               fontSize: { xs: '1.8rem', sm: '2.5rem', md: '3.2rem' },
               lineHeight: { xs: 1.2, sm: 1.3 },
-              color: 'var(--text-primary)' // Explicitly set to ensure visibility
+              color: 'var(--text-primary) !important' // Explicitly set to ensure visibility
             }}
           >
             Ace Your System Design Interview
@@ -73,7 +73,7 @@ const HomePage = () => {
               // mb: 4, // Typography with paragraph prop already adds margin-bottom. Adjust if more space is needed.
               fontSize: { xs: '0.9rem', sm: '1rem', md: '1.15rem' },
               lineHeight: { xs: 1.3, sm: 1.4 },
-              color: 'var(--text-secondary)' // Explicitly set for visibility
+              color: 'var(--text-secondary) !important' // Explicitly set for visibility
             }}
           >
             Comprehensive study guides designed to help you master complex topics and impress in your next technical interview.
@@ -86,7 +86,7 @@ const HomePage = () => {
       <Box sx={{ textAlign: 'center', py: { xs: 4, sm: 6 } }}>
 
         {/* Guides Section */}
-        <Typography variant="h4" component="h2" sx={{ mb: 6, fontWeight:'bold', color: 'var(--text-primary)' }}>
+        <Typography variant="h4" component="h2" sx={{ mb: 6, fontWeight:'bold', color: 'var(--text-primary) !important' }}>
           Featured Study Guides
         </Typography>
         {/* Updated to make the grid responsive with more items */}


### PR DESCRIPTION
Applied `!important` to the `color` style within `sx` props for the hero section's main Box, title, subtitle, and the "Featured Study Guides" title in `HomePage.jsx`.

This is to ensure that the theme-defined text colors (`var(--text-primary)` and `var(--text-secondary)`) are applied and override any potentially conflicting global or more specific styles that were causing the text to remain black in dark mode.