### PR TITLE
Fix topic links and add detail pages

### DIFF
--- a/system-design-study-app/src/App.jsx
+++ b/system-design-study-app/src/App.jsx
@@ -20,6 +20,7 @@ const ApiDesignPage = lazy(() => import('./components/apidesign/ApiDesignPage'))
 const ScalabilityConceptsPage = lazy(() => import('./components/scalabilityconcepts/ScalabilityConceptsPage'));
 const InterviewApproachPage = lazy(() => import('./components/interviewapproach/InterviewApproachPage'));
 const TopicsListPage = lazy(() => import('./pages/TopicsListPage')); // Added new Topics List Page
+const TopicDetailPage = lazy(() => import('./pages/TopicDetailPage'));
 
 // Inner component to access both Auth and CustomTheme contexts
 function AppContent() {
@@ -44,6 +45,7 @@ function AppContent() {
               <Route path="/scalability-concepts" element={<ScalabilityConceptsPage />} />
               <Route path="/interview-approach" element={<InterviewApproachPage />} />
               <Route path="/topics" element={<TopicsListPage />} /> {/* Added route for Topics List Page */}
+              <Route path="/topic/:topicId" element={<TopicDetailPage />} />
             </Routes>
           </Suspense>
         </Layout>

--- a/system-design-study-app/src/data/topicsData.js
+++ b/system-design-study-app/src/data/topicsData.js
@@ -1,0 +1,72 @@
+export const topicsData = [
+  {
+    id: 'cache-client-side',
+    title: 'Client-Side Caching',
+    category: 'Caching',
+    description: 'Caching data directly in the client application (e.g., browser or mobile cache).',
+    content: 'Client-side caching reduces latency by storing recently accessed data on the user\'s device. It is useful for static or infrequently changing resources but requires strategies for invalidation and data freshness.'
+  },
+  {
+    id: 'cache-cdn',
+    title: 'CDN (Content Delivery Network)',
+    category: 'Caching',
+    description: 'Geographically distributed network of proxy servers caching content closer to users.',
+    content: 'CDNs replicate content across edge locations worldwide, improving load times and reliability for static assets such as images or scripts.'
+  },
+  {
+    id: 'cache-write-through',
+    title: 'Write-Through Cache',
+    category: 'Caching Patterns',
+    description: 'Data is written to cache and origin simultaneously.',
+    content: 'Write-through ensures the cache is always up to date, simplifying reads at the cost of higher write latency.'
+  },
+  {
+    id: 'db-sql-vs-nosql',
+    title: 'SQL vs NoSQL Databases',
+    category: 'Databases',
+    description: 'Understanding the differences, use cases, advantages, and disadvantages of SQL and NoSQL databases.',
+    content: 'Relational databases provide ACID guarantees and flexible querying with SQL, whereas NoSQL options trade some consistency for scalability and schema flexibility.'
+  },
+  {
+    id: 'db-cap-theorem',
+    title: 'CAP Theorem',
+    category: 'Databases',
+    description: 'Exploring Consistency, Availability, and Partition Tolerance in distributed databases.',
+    content: 'CAP states that a distributed system can provide at most two of the three guarantees. Designers must choose between CP and AP based on application needs.'
+  },
+  {
+    id: 'mq-rabbitmq',
+    title: 'RabbitMQ Overview',
+    category: 'Messaging Queues',
+    description: 'An overview of RabbitMQ, its architecture, and common use cases.',
+    content: 'RabbitMQ is a popular open source message broker implementing the AMQP protocol. It supports flexible routing, acknowledgments, and plugins for reliability.'
+  },
+  {
+    id: 'mq-kafka',
+    title: 'Apache Kafka Fundamentals',
+    category: 'Messaging Queues',
+    description: 'Introduction to Apache Kafka for stream processing and message queuing.',
+    content: 'Kafka is designed for high-throughput, persistent event streaming. Topics are partitioned for scalability and replicated for fault tolerance.'
+  },
+  {
+    id: 'api-security',
+    title: 'API Security Basics',
+    category: 'API Design',
+    description: 'Key considerations for securing APIs including authentication and encryption.',
+    content: 'Secure APIs with TLS, token based authentication (OAuth, JWT), proper authorization checks, and input validation to prevent common vulnerabilities.'
+  },
+  {
+    id: 'lb-round-robin',
+    title: 'Load Balancing Algorithms',
+    category: 'Load Balancing',
+    description: 'Strategies like round-robin and least-connections to distribute traffic.',
+    content: 'Load balancers spread requests across servers using algorithms. Round-robin is simple, while least-connections sends traffic to the least busy server.'
+  },
+  {
+    id: 'scaling-horizontal',
+    title: 'Horizontal vs Vertical Scaling',
+    category: 'Scalability Concepts',
+    description: 'Understanding when to add more servers versus more powerful servers.',
+    content: 'Horizontal scaling adds more nodes to handle load, improving availability. Vertical scaling increases resources on a single node but has hardware limits.'
+  }
+];

--- a/system-design-study-app/src/pages/TopicDetailPage.jsx
+++ b/system-design-study-app/src/pages/TopicDetailPage.jsx
@@ -1,0 +1,64 @@
+import React, { useEffect } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Box, Typography, Container } from '@mui/material';
+import { setMetaTag, removeMetaTag } from '../utils/metaUtils';
+import { topicsData } from '../data/topicsData';
+
+const TopicDetailPage = () => {
+  const { topicId } = useParams();
+  const topic = topicsData.find(t => t.id === topicId);
+
+  useEffect(() => {
+    if (!topic) return;
+    const originalTitle = document.title;
+    const pageTitle = `${topic.title} | System Design Guide`;
+    const pageDescription = topic.description;
+
+    document.title = pageTitle;
+    const metaTags = [
+      { name: 'description', content: pageDescription },
+      { name: 'og:title', content: pageTitle, isProperty: true },
+      { name: 'og:description', content: pageDescription, isProperty: true }
+    ];
+    metaTags.forEach(tag => setMetaTag(tag.name, tag.content, tag.isProperty));
+
+    return () => {
+      document.title = originalTitle;
+      metaTags.forEach(tag => removeMetaTag(tag.name, tag.isProperty));
+    };
+  }, [topic]);
+
+  if (!topic) {
+    return (
+      <Container sx={{ py: 6 }}>
+        <Typography variant="h4" gutterBottom>
+          Topic Not Found
+        </Typography>
+        <Typography paragraph>
+          We couldn't find the topic you're looking for.
+        </Typography>
+        <Link to="/topics">Back to Topics</Link>
+      </Container>
+    );
+  }
+
+  return (
+    <Container sx={{ py: 6 }}>
+      <Typography variant="h3" gutterBottom>
+        {topic.title}
+      </Typography>
+      <Typography variant="subtitle1" gutterBottom color="text.secondary">
+        Category: {topic.category}
+      </Typography>
+      <Typography paragraph>{topic.description}</Typography>
+      <Box sx={{ mt: 2 }}>
+        <Typography variant="body1">{topic.content}</Typography>
+      </Box>
+      <Box sx={{ mt: 4 }}>
+        <Link to="/topics">Back to Topics</Link>
+      </Box>
+    </Container>
+  );
+};
+
+export default TopicDetailPage;

--- a/system-design-study-app/src/pages/TopicsListPage.jsx
+++ b/system-design-study-app/src/pages/TopicsListPage.jsx
@@ -1,93 +1,24 @@
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import SearchInput from '../components/common/SearchInput';
-import Card from '../components/common/Card'; // Assuming Card component can be used here
-import Button from '../components/common/Button'; // Assuming Button component can be used
+import Card from '../components/common/Card';
+import Button from '../components/common/Button';
+import { topicsData } from '../data/topicsData';
 
-// Sample aggregated topics data
-// In a real app, this would be dynamically generated from all ...AppData.js files
-const ALL_APP_TOPICS = [
-  // From Caches
-  {
-    id: 'cache-client-side',
-    title: 'Client-Side Caching',
-    category: 'Caching',
-    description: 'Caching data directly in the client application (e.g., browser cache, mobile app cache).',
-    path: '/caches/client-side' // Example path, actual routing needs to be defined
-  },
-  {
-    id: 'cache-cdn',
-    title: 'CDN (Content Delivery Network)',
-    category: 'Caching',
-    description: 'Geographically distributed network of proxy servers caching content closer to users.',
-    path: '/caches/cdn'
-  },
-  {
-    id: 'cache-write-through',
-    title: 'Write-Through Cache',
-    category: 'Caching Patterns',
-    description: 'Data is written to cache and origin simultaneously.',
-    path: '/caches/write-patterns/write-through'
-  },
-  // From Databases (example structure)
-  {
-    id: 'db-sql-vs-nosql',
-    title: 'SQL vs NoSQL Databases',
-    category: 'Databases',
-    description: 'Understanding the differences, use cases, advantages, and disadvantages of SQL and NoSQL databases.',
-    path: '/databases/sql-vs-nosql'
-  },
-  {
-    id: 'db-cap-theorem',
-    title: 'CAP Theorem',
-    category: 'Databases',
-    description: 'Exploring Consistency, Availability, and Partition Tolerance in distributed database systems.',
-    path: '/databases/cap-theorem'
-  },
-  // From Messaging Queues (example structure)
-  {
-    id: 'mq-rabbitmq',
-    title: 'RabbitMQ Overview',
-    category: 'Messaging Queues',
-    description: 'An overview of RabbitMQ, its architecture, and common use cases.',
-    path: '/messaging-queues/rabbitmq'
-  },
-  {
-    id: 'mq-kafka',
-    title: 'Apache Kafka Fundamentals',
-    category: 'Messaging Queues',
-    description: 'Introduction to Apache Kafka for stream processing and message queuing.',
-    path: '/messaging-queues/kafka'
-  },
-  // Generic example
-  {
-    id: 'intro-react',
-    title: 'Introduction to React',
-    category: 'Web Development',
-    description: 'Learn the basics of React, including components, props, and state.',
-    path: '/learn/react-basics'
-  },
-  {
-    id: 'js-async',
-    title: 'Asynchronous JavaScript',
-    category: 'JavaScript',
-    description: 'Understand promises, async/await, and how to handle asynchronous operations in JavaScript.',
-    path: '/learn/js-async'
-  }
-];
+const TOP_TOPICS = topicsData.slice(0, 10);
 
 const TopicsListPage = () => {
   const [searchTerm, setSearchTerm] = useState('');
-  const [filteredTopics, setFilteredTopics] = useState(ALL_APP_TOPICS);
+  const [filteredTopics, setFilteredTopics] = useState(TOP_TOPICS);
 
   useEffect(() => {
     const lowercasedFilter = searchTerm.toLowerCase();
-    const filtered = ALL_APP_TOPICS.filter(topic => {
+    const filtered = topicsData.filter(topic => {
       return topic.title.toLowerCase().includes(lowercasedFilter) ||
              topic.description.toLowerCase().includes(lowercasedFilter) ||
              topic.category.toLowerCase().includes(lowercasedFilter);
     });
-    setFilteredTopics(filtered);
+    setFilteredTopics(filtered.slice(0, 10));
   }, [searchTerm]);
 
   const handleSearchChange = (value) => {
@@ -121,7 +52,7 @@ const TopicsListPage = () => {
                 <p className="text-neutral-700 dark:text-neutral-300 text-sm mb-4 line-clamp-3">{topic.description}</p>
               </div>
               <div className="p-5 border-t border-neutral-200 dark:border-neutral-700 mt-auto">
-                <Link to={topic.path}>
+                <Link to={`/topic/${topic.id}`}>
                   <Button variant="secondary" size="sm" className="w-full">View Topic</Button>
                 </Link>
               </div>


### PR DESCRIPTION
## Summary
- create `topicsData.js` for a canonical list of study topics
- add a new `TopicDetailPage` with meta tags
- route `/topic/:topicId` to `TopicDetailPage`
- update `TopicsListPage` to show only the top 10 topics and link to the new route

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6c0c09f083309628ca1b677160fd