### PR TITLE
Fix: Centralize Mermaid initialization and refine rendering

### DIFF
--- a/system-design-study-app/src/main.jsx
+++ b/system-design-study-app/src/main.jsx
@@ -2,6 +2,32 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css' // Tailwind directives
+import mermaid from 'mermaid';
+
+// Try to address potential D3 conflicts and initialize Mermaid early
+try {
+  // If another version of d3 is loaded, it might conflict.
+  // This is a workaround suggested in some Mermaid GitHub issues.
+  if (window.d3) {
+    console.log("Found existing window.d3, attempting to delete to avoid conflict with Mermaid's D3.");
+    delete window.d3;
+  }
+} catch (e) {
+  console.error("Error trying to delete window.d3:", e);
+}
+
+try {
+  console.log("Attempting to initialize Mermaid globally from main.jsx...");
+  mermaid.initialize({
+    startOnLoad: false, // We will control rendering manually
+    theme: 'default', // Or your preferred theme
+    // Add other global configurations if needed
+  });
+  console.log("Mermaid initialized globally from main.jsx.");
+} catch (e) {
+  console.error("Error initializing Mermaid in main.jsx:", e);
+  // Potentially display a global error message to the user or log more aggressively
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
- Moved Mermaid initialization to main.jsx to ensure it runs once, early.
- Attempted to mitigate D3 conflicts by deleting window.d3 before init.
- Refactored MermaidDiagram.jsx to remove local initialization.
- Updated rendering logic in MermaidDiagram.jsx to use async/await with mermaid.render.

These changes aim to resolve the 'createElementNS' error and improve stability of Mermaid diagram rendering.