### PR TITLE
Debug: Simplify writeBack diagram syntax

### DIFF
--- a/system-design-study-app/src/data/cachesAppData.js
+++ b/system-design-study-app/src/data/cachesAppData.js
@@ -22,8 +22,8 @@ sequenceDiagram
 `,
     writeBack: `
 flowchart TD
-    App-->Cache: write(data)
-    Cache-- async -->DB: write(data)
+    App-->Cache
+    Cache-->DB: write(data) // Original "Cache-- async -->DB: write(data)"
     style Cache fill:#f9f,stroke:#333,stroke-width:1px
     note over Cache: Cache acknowledges immediately
 `


### PR DESCRIPTION
Simplified the Mermaid definition for the 'writeBack' diagram in cachesAppData.js to help diagnose a persistent parse error. This is a temporary debugging step.

Centralized Mermaid initialization and other rendering refinements from previous commits are included.