### PR TITLE
Debug: Comment out note in writeBack diagram for testing

### DIFF
--- a/system-design-study-app/src/data/cachesAppData.js
+++ b/system-design-study-app/src/data/cachesAppData.js
@@ -22,10 +22,10 @@ sequenceDiagram
 `,
     writeBack: `
 flowchart TD
-    App-->Cache
-    Cache-->DB: write(data) // Original "Cache-- async -->DB: write(data)"
+    App-- "write(data)" -->Cache
+    Cache-- "async" -->DB_Node["DB: write(data)"]
     style Cache fill:#f9f,stroke:#333,stroke-width:1px
-    note over Cache: Cache acknowledges immediately
+    %% note over Cache: "Cache acknowledges immediately"
 `
   },
   metrics: [


### PR DESCRIPTION
Temporarily commented out the 'note' directive in the 'writeBack' Mermaid diagram definition within cachesAppData.js.

This is part of an ongoing effort to diagnose and fix parsing errors in Mermaid diagrams. Previous commits in this branch addressed the general 'createElementNS' rendering error and began tackling individual diagram syntax issues by quoting labels.